### PR TITLE
Add exception middleware to API

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -2,6 +2,7 @@
 using Infrastructure;
 using Api.BackgroundServices;
 using Microsoft.EntityFrameworkCore;
+using ISKI.Core.CrossCuttingConcerns.Exceptions.ExceptionHandling;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -25,6 +26,8 @@ if (app.Environment.IsDevelopment())
         return Task.CompletedTask;
     });
 }
+
+app.UseMiddleware<ExceptionMiddleware>();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- import `ExceptionMiddleware`
- register `ExceptionMiddleware` before controller mapping

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867808b91b48324abfd63fd2e609277