### PR TITLE
Add Turkish constants for business rule errors

### DIFF
--- a/Application/Features/AnalogSensorDatas/Constants/AnalogSensorDataMessages.cs
+++ b/Application/Features/AnalogSensorDatas/Constants/AnalogSensorDataMessages.cs
@@ -1,0 +1,6 @@
+namespace Application.Features.AnalogSensorDatas.Constants;
+
+public static class AnalogSensorDataMessages
+{
+    public const string NotFound = "Kayıt bulunamadı.";
+}

--- a/Application/Features/AnalogSensorDatas/Rules/AnalogSensorDataBusinessRules.cs
+++ b/Application/Features/AnalogSensorDatas/Rules/AnalogSensorDataBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.AnalogSensorDatas.Constants;
+namespace Application.Features.AnalogSensorDatas.Rules;
+
+public static class AnalogSensorDataBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(AnalogSensorDataMessages.NotFound);
+    }
+}

--- a/Application/Features/ApiEndpoints/Constants/ApiEndpointMessages.cs
+++ b/Application/Features/ApiEndpoints/Constants/ApiEndpointMessages.cs
@@ -5,4 +5,5 @@ public static class ApiEndpointMessages
     public const string Created = "ApiEndpoint created.";
     public const string Updated = "ApiEndpoint updated.";
     public const string Deleted = "ApiEndpoint deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/ApiEndpoints/Rules/ApiEndpointBusinessRules.cs
+++ b/Application/Features/ApiEndpoints/Rules/ApiEndpointBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.ApiEndpoints.Constants;
+namespace Application.Features.ApiEndpoints.Rules;
+
+public static class ApiEndpointBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(ApiEndpointMessages.NotFound);
+    }
+}

--- a/Application/Features/CalibrationLimits/Constants/CalibrationLimitMessages.cs
+++ b/Application/Features/CalibrationLimits/Constants/CalibrationLimitMessages.cs
@@ -5,4 +5,5 @@ public static class CalibrationLimitMessages
     public const string Created = "CalibrationLimit created.";
     public const string Updated = "CalibrationLimit updated.";
     public const string Deleted = "CalibrationLimit deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/CalibrationLimits/Rules/CalibrationLimitBusinessRules.cs
+++ b/Application/Features/CalibrationLimits/Rules/CalibrationLimitBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.CalibrationLimits.Constants;
+namespace Application.Features.CalibrationLimits.Rules;
+
+public static class CalibrationLimitBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(CalibrationLimitMessages.NotFound);
+    }
+}

--- a/Application/Features/CalibrationMeasurements/Constants/CalibrationMeasurementMessages.cs
+++ b/Application/Features/CalibrationMeasurements/Constants/CalibrationMeasurementMessages.cs
@@ -5,4 +5,5 @@ public static class CalibrationMeasurementMessages
     public const string Created = "CalibrationMeasurement created.";
     public const string Updated = "CalibrationMeasurement updated.";
     public const string Deleted = "CalibrationMeasurement deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/CalibrationMeasurements/Rules/CalibrationMeasurementBusinessRules.cs
+++ b/Application/Features/CalibrationMeasurements/Rules/CalibrationMeasurementBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.CalibrationMeasurements.Constants;
+namespace Application.Features.CalibrationMeasurements.Rules;
+
+public static class CalibrationMeasurementBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(CalibrationMeasurementMessages.NotFound);
+    }
+}

--- a/Application/Features/DigitalSensorDatas/Constants/DigitalSensorDataMessages.cs
+++ b/Application/Features/DigitalSensorDatas/Constants/DigitalSensorDataMessages.cs
@@ -5,4 +5,5 @@ public static class DigitalSensorDataMessages
     public const string Created = "DigitalSensorData created.";
     public const string Updated = "DigitalSensorData updated.";
     public const string Deleted = "DigitalSensorData deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/DigitalSensorDatas/Rules/DigitalSensorDataBusinessRules.cs
+++ b/Application/Features/DigitalSensorDatas/Rules/DigitalSensorDataBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.DigitalSensorDatas.Constants;
+namespace Application.Features.DigitalSensorDatas.Rules;
+
+public static class DigitalSensorDataBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(DigitalSensorDataMessages.NotFound);
+    }
+}

--- a/Application/Features/MailLogs/Constants/MailLogMessages.cs
+++ b/Application/Features/MailLogs/Constants/MailLogMessages.cs
@@ -3,4 +3,5 @@ namespace Application.Features.MailLogs.Constants;
 public static class MailLogMessages
 {
     public const string Listed = "Mail logları başarıyla listelendi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/MailLogs/Rules/MailLogBusinessRules.cs
+++ b/Application/Features/MailLogs/Rules/MailLogBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.MailLogs.Constants;
+namespace Application.Features.MailLogs.Rules;
+
+public static class MailLogBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(MailLogMessages.NotFound);
+    }
+}

--- a/Application/Features/MailSettings/Constants/MailSettingsMessages.cs
+++ b/Application/Features/MailSettings/Constants/MailSettingsMessages.cs
@@ -6,4 +6,5 @@ public static class MailSettingsMessages
     public const string Created = "Mail ayarı başarıyla oluşturuldu.";
     public const string Updated = "Mail ayarı başarıyla güncellendi.";
     public const string Deleted = "Mail ayarı başarıyla silindi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/MailSettings/Rules/MailSettingBusinessRules.cs
+++ b/Application/Features/MailSettings/Rules/MailSettingBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.MailSettings.Constants;
+namespace Application.Features.MailSettings.Rules;
+
+public static class MailSettingBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(MailSettingsMessages.NotFound);
+    }
+}

--- a/Application/Features/MailTriggerRecipients/Constants/MailTriggerRecipientMessages.cs
+++ b/Application/Features/MailTriggerRecipients/Constants/MailTriggerRecipientMessages.cs
@@ -4,4 +4,5 @@ public static class MailTriggerRecipientMessages
 {
     public const string Created = "Mail tetikleyici alıcısı başarıyla oluşturuldu.";
     public const string Deleted = "Mail tetikleyici alıcısı başarıyla silindi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/MailTriggerRecipients/Rules/MailTriggerRecipientBusinessRules.cs
+++ b/Application/Features/MailTriggerRecipients/Rules/MailTriggerRecipientBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.MailTriggerRecipients.Constants;
+namespace Application.Features.MailTriggerRecipients.Rules;
+
+public static class MailTriggerRecipientBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(MailTriggerRecipientMessages.NotFound);
+    }
+}

--- a/Application/Features/MailTriggers/Constants/MailTriggerMessages.cs
+++ b/Application/Features/MailTriggers/Constants/MailTriggerMessages.cs
@@ -5,4 +5,5 @@ public static class MailTriggerMessages
     public const string Created = "Mail tetikleyici başarıyla oluşturuldu.";
     public const string Updated = "Mail tetikleyici başarıyla güncellendi.";
     public const string Deleted = "Mail tetikleyici başarıyla silindi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/MailTriggers/Rules/MailTriggerBusinessRules.cs
+++ b/Application/Features/MailTriggers/Rules/MailTriggerBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.MailTriggers.Constants;
+namespace Application.Features.MailTriggers.Rules;
+
+public static class MailTriggerBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(MailTriggerMessages.NotFound);
+    }
+}

--- a/Application/Features/MailUsers/Constants/MailUserMessages.cs
+++ b/Application/Features/MailUsers/Constants/MailUserMessages.cs
@@ -6,4 +6,5 @@ public static class MailUserMessages
     public const string Created = "Mail kullanıcısı başarıyla oluşturuldu.";
     public const string Updated = "Mail kullanıcısı başarıyla güncellendi.";
     public const string Deleted = "Mail kullanıcısı başarıyla silindi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/MailUsers/Rules/MailUserBusinessRules.cs
+++ b/Application/Features/MailUsers/Rules/MailUserBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.MailUsers.Constants;
+namespace Application.Features.MailUsers.Rules;
+
+public static class MailUserBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(MailUserMessages.NotFound);
+    }
+}

--- a/Application/Features/PlcData/Constants/PlcDataMessages.cs
+++ b/Application/Features/PlcData/Constants/PlcDataMessages.cs
@@ -1,0 +1,6 @@
+namespace Application.Features.PlcData.Constants;
+
+public static class PlcDataMessages
+{
+    public const string NotFound = "Kayıt bulunamadı.";
+}

--- a/Application/Features/PlcData/Rules/PlcDataBusinessRules.cs
+++ b/Application/Features/PlcData/Rules/PlcDataBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.PlcData.Constants;
+namespace Application.Features.PlcData.Rules;
+
+public static class PlcDataBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(PlcDataMessages.NotFound);
+    }
+}

--- a/Application/Features/PlcInformations/Constants/PlcInformationMessages.cs
+++ b/Application/Features/PlcInformations/Constants/PlcInformationMessages.cs
@@ -5,4 +5,5 @@ public static class PlcInformationMessages
     public const string Created = "Plc information created.";
     public const string Updated = "Plc information updated.";
     public const string Deleted = "Plc information deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/PlcInformations/Rules/PlcInformationBusinessRules.cs
+++ b/Application/Features/PlcInformations/Rules/PlcInformationBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.PlcInformations.Constants;
+namespace Application.Features.PlcInformations.Rules;
+
+public static class PlcInformationBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(PlcInformationMessages.NotFound);
+    }
+}

--- a/Application/Features/SendDatas/Constants/SendDataMessages.cs
+++ b/Application/Features/SendDatas/Constants/SendDataMessages.cs
@@ -3,4 +3,5 @@ namespace Application.Features.SendDatas.Constants;
 public static class SendDataMessages
 {
     public const string Processed = "Veri başarıyla işlendi.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/SendDatas/Rules/SendDataBusinessRules.cs
+++ b/Application/Features/SendDatas/Rules/SendDataBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.SendDatas.Constants;
+namespace Application.Features.SendDatas.Rules;
+
+public static class SendDataBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(SendDataMessages.NotFound);
+    }
+}

--- a/Application/Features/Stations/Constants/StationMessages.cs
+++ b/Application/Features/Stations/Constants/StationMessages.cs
@@ -5,4 +5,5 @@ public static class StationMessages
     public const string Created = "Station created.";
     public const string Updated = "Station updated.";
     public const string Deleted = "Station deleted.";
+    public const string NotFound = "Kayıt bulunamadı.";
 }

--- a/Application/Features/Stations/Rules/StationBusinessRules.cs
+++ b/Application/Features/Stations/Rules/StationBusinessRules.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Application.Features.Stations.Constants;
+namespace Application.Features.Stations.Rules;
+
+public static class StationBusinessRules
+{
+    public static void EntityShouldNotBeNull(object? entity)
+    {
+        if (entity is null)
+            throw new KeyNotFoundException(StationMessages.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary
- create constants for analog sensor and PLC data features
- add `NotFound` messages in Turkish across feature constants
- use the constants in business rule checks to throw `KeyNotFoundException`

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678288c3648324a7b2fab4c993b22e