### PR TITLE
Add PLC data service for WinUI

### DIFF
--- a/WinUI/Models/AnalogSensorDataDto.cs
+++ b/WinUI/Models/AnalogSensorDataDto.cs
@@ -1,0 +1,18 @@
+namespace WinUI.Models;
+
+public class AnalogSensorDataDto
+{
+    public int Id { get; set; }
+    public DateTime Readtime { get; set; }
+    public double AkisHizi { get; set; }
+    public double Akm { get; set; }
+    public double CozunmusOksijen { get; set; }
+    public double Debi { get; set; }
+    public double? DesarjDebi { get; set; }
+    public double? HariciDebi { get; set; }
+    public double? HariciDebi2 { get; set; }
+    public double Koi { get; set; }
+    public double Ph { get; set; }
+    public double Sicaklik { get; set; }
+    public double Iletkenlik { get; set; }
+}

--- a/WinUI/Models/DigitalSensorDataDto.cs
+++ b/WinUI/Models/DigitalSensorDataDto.cs
@@ -1,0 +1,18 @@
+namespace WinUI.Models;
+
+public class DigitalSensorDataDto
+{
+    public int Id { get; set; }
+    public DateTime ReadTime { get; set; }
+    public bool Kapi { get; set; }
+    public bool Duman { get; set; }
+    public bool SuBaskini { get; set; }
+    public bool AcilStop { get; set; }
+    public bool Pompa1Termik { get; set; }
+    public bool Pompa2Termik { get; set; }
+    public bool TemizSuTermik { get; set; }
+    public bool YikamaTanki { get; set; }
+    public bool Enerji { get; set; }
+    public bool Pompa1CalisiyorMu { get; set; }
+    public bool Pompa2CalisiyorMu { get; set; }
+}

--- a/WinUI/Models/PlcDataDto.cs
+++ b/WinUI/Models/PlcDataDto.cs
@@ -1,0 +1,7 @@
+namespace WinUI.Models;
+
+public class PlcDataDto
+{
+    public required AnalogSensorDataDto Analog { get; set; }
+    public required DigitalSensorDataDto Digital { get; set; }
+}

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -7,14 +7,24 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using WinUI.Models;
+using WinUI.Services;
 
 namespace WinUI.Pages
 {
-    public partial class HomePage: UserControl
+    public partial class HomePage : UserControl
     {
-        public HomePage()
+        private readonly IPlcDataService _plcService;
+
+        public HomePage(IPlcDataService plcService)
         {
             InitializeComponent();
+            _plcService = plcService;
+        }
+
+        public Task<PlcDataDto?> ReadPlcDataAsync()
+        {
+            return _plcService.ReadAndSaveAsync();
         }
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using WinUI.Forms;
 using WinUI.Pages;
+using WinUI.Services;
 
 namespace WinUI
 {
@@ -42,6 +43,13 @@ namespace WinUI
                     services.AddSingleton<SimulationPage>();
                     services.AddSingleton<ReportingPage>();
                     services.AddSingleton<MailPage>();
+
+                    services.AddHttpClient<IPlcDataService, PlcDataService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "http://localhost:62731";
+                        if (!baseUrl.EndsWith('/')) baseUrl += "/";
+                        client.BaseAddress = new Uri(baseUrl);
+                    });
                 });
     }
 }

--- a/WinUI/Services/IPlcDataService.cs
+++ b/WinUI/Services/IPlcDataService.cs
@@ -1,0 +1,8 @@
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IPlcDataService
+{
+    Task<PlcDataDto?> ReadAndSaveAsync();
+}

--- a/WinUI/Services/PlcDataService.cs
+++ b/WinUI/Services/PlcDataService.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public class PlcDataService(HttpClient httpClient) : IPlcDataService
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task<PlcDataDto?> ReadAndSaveAsync()
+    {
+        using var response = await _httpClient.PostAsync("api/plcdata/read", null);
+        response.EnsureSuccessStatusCode();
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        return await response.Content.ReadFromJsonAsync<PlcDataDto>(options);
+    }
+}

--- a/WinUI/WinUI.csproj
+++ b/WinUI/WinUI.csproj
@@ -39,4 +39,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/WinUI/appsettings.json
+++ b/WinUI/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Api": {
+    "BaseUrl": "http://localhost:62731"
+  }
+}


### PR DESCRIPTION
## Summary
- create PLC data DTOs and service in WinUI
- register HttpClient and service
- inject service into `HomePage`
- add appsettings for API base URL

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686791220fb08324aab93dc94d29ed74