### PR TITLE
Add PLC time parameters query

### DIFF
--- a/Api/Controllers/PlcDataController.cs
+++ b/Api/Controllers/PlcDataController.cs
@@ -1,4 +1,5 @@
 using Application.Features.PlcData.Commands.ReadAndSavePlcData;
+using Application.Features.PlcData.Queries.GetTimeParameters;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,6 +9,25 @@ namespace Api.Controllers;
 [Route("api/[controller]")]
 public class PlcDataController(IMediator mediator, IConfiguration configuration) : ControllerBase
 {
+    [HttpGet("time-parameters")]
+    public async Task<IActionResult> GetTimeParameters()
+    {
+        var query = new GetPlcTimeParametersQuery(
+            configuration["PlcSettings:IpAddress"] ?? "10.33.3.253",
+            configuration.GetValue<int>("PlcSettings:TimeDb"),
+            configuration.GetValue<int>("PlcSettings:TimeStart"),
+            configuration.GetValue<int>("PlcSettings:TimeLength"));
+
+        try
+        {
+            var result = await mediator.Send(query);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { Message = ex.Message });
+        }
+    }
     [HttpPost("read")]
     public async Task<IActionResult> ReadAndSave()
     {

--- a/Api/appsettings.json
+++ b/Api/appsettings.json
@@ -10,6 +10,9 @@
     "DigitalDb": 42,
     "DigitalStart": 0,
     "DigitalLength": 3,
-    "IntervalSeconds": 30
+    "IntervalSeconds": 30,
+    "TimeDb": 43,
+    "TimeStart": 0,
+    "TimeLength": 20
   }
 }

--- a/Application/Features/PlcData/Profiles/PlcTimeParametersProfile.cs
+++ b/Application/Features/PlcData/Profiles/PlcTimeParametersProfile.cs
@@ -1,0 +1,13 @@
+using Application.Features.PlcData.Dtos;
+using AutoMapper;
+using Domain.Entities;
+
+namespace Application.Features.PlcData.Profiles;
+
+public class PlcTimeParametersProfile : Profile
+{
+    public PlcTimeParametersProfile()
+    {
+        CreateMap<PlcTimeParameters, PlcTimeParametersDto>();
+    }
+}

--- a/Application/Features/PlcData/Queries/GetTimeParameters/GetPlcTimeParametersQuery.cs
+++ b/Application/Features/PlcData/Queries/GetTimeParameters/GetPlcTimeParametersQuery.cs
@@ -1,0 +1,6 @@
+using Application.Features.PlcData.Dtos;
+using MediatR;
+
+namespace Application.Features.PlcData.Queries.GetTimeParameters;
+
+public record GetPlcTimeParametersQuery(string IpAddress, int DbNumber, int Start, int Length) : IRequest<PlcTimeParametersDto>;

--- a/Application/Features/PlcData/Queries/GetTimeParameters/GetPlcTimeParametersQueryHandler.cs
+++ b/Application/Features/PlcData/Queries/GetTimeParameters/GetPlcTimeParametersQueryHandler.cs
@@ -1,0 +1,22 @@
+using Application.Features.PlcData.Dtos;
+using Application.Services.Parsing;
+using AutoMapper;
+using Infrastructure.Services.PLC;
+using Application.Features.PlcData.Rules;
+using MediatR;
+
+namespace Application.Features.PlcData.Queries.GetTimeParameters;
+
+public class GetPlcTimeParametersQueryHandler(
+    IPlcClient plcClient,
+    IPlcDataParser parser,
+    IMapper mapper) : IRequestHandler<GetPlcTimeParametersQuery, PlcTimeParametersDto>
+{
+    public async Task<PlcTimeParametersDto> Handle(GetPlcTimeParametersQuery request, CancellationToken cancellationToken)
+    {
+        byte[] bytes = await plcClient.ReadBytesAsync(request.IpAddress, request.DbNumber, request.Start, request.Length);
+        var entity = parser.ParseTimeParameters(bytes);
+        PlcDataBusinessRules.EntityShouldNotBeNull(entity);
+        return mapper.Map<PlcTimeParametersDto>(entity);
+    }
+}

--- a/Application/Services/Parsing/IPlcDataParser.cs
+++ b/Application/Services/Parsing/IPlcDataParser.cs
@@ -9,4 +9,5 @@ public interface IPlcDataParser
 {
     AnalogSensorData ParseAnalog(byte[] data);
     DigitalSensorData ParseDigital(byte[] data);
+    PlcTimeParameters ParseTimeParameters(byte[] data);
 }

--- a/Application/Services/Parsing/PlcDataParser.cs
+++ b/Application/Services/Parsing/PlcDataParser.cs
@@ -49,6 +49,19 @@ public class PlcDataParser : IPlcDataParser
         };
     }
 
+    public PlcTimeParameters ParseTimeParameters(byte[] data)
+    {
+        return new PlcTimeParameters
+        {
+            SystemTime = ReadTime(data, 0),
+            WeeklyWashDay = ReadByte(data, 12),
+            WeeklyWashHour = ReadByte(data, 13),
+            DailyWashHour = ReadByte(data, 14),
+            Minute = ReadByte(data, 15),
+            Second = ReadByte(data, 16)
+        };
+    }
+
     public static double ReadReal(byte[] buffer, int offset, int divider = 1)
     {
         double value = S7.GetRealAt(buffer, offset) / divider;

--- a/Domain/Entities/PlcTimeParameters.cs
+++ b/Domain/Entities/PlcTimeParameters.cs
@@ -1,0 +1,15 @@
+namespace Domain.Entities;
+
+/// <summary>
+/// Represents time configuration parameters read from the PLC.
+/// These values are not persisted but mapped to DTOs when requested.
+/// </summary>
+public class PlcTimeParameters
+{
+    public DateTime SystemTime { get; set; }
+    public byte WeeklyWashDay { get; set; }
+    public byte WeeklyWashHour { get; set; }
+    public byte DailyWashHour { get; set; }
+    public byte Minute { get; set; }
+    public byte Second { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `PlcTimeParameters` domain model
- extend PLC data parser with time parameter support
- create query/handler/profile for reading PLC time data
- expose new `time-parameters` endpoint in `PlcDataController`
- wire up configuration values in `appsettings.json`

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686792bb9cc88324952273cd2938b18c