### PR TITLE
Implement PLC state colors and tracking

### DIFF
--- a/WinUI/Helpers/StateColors.cs
+++ b/WinUI/Helpers/StateColors.cs
@@ -1,0 +1,24 @@
+using System.Drawing;
+
+namespace WinUI.Helpers;
+
+/// <summary>
+/// Central definition of colors used for PLC and sensor states.
+/// </summary>
+public static class StateColors
+{
+    /// <summary>
+    /// Color used when status is unknown or data has not been retrieved yet.
+    /// </summary>
+    public static readonly Color Waiting = Color.Gray;
+
+    /// <summary>
+    /// Color used when the PLC connection and data are healthy.
+    /// </summary>
+    public static readonly Color Ok = Color.LimeGreen;
+
+    /// <summary>
+    /// Color used when an error occurs while retrieving PLC data.
+    /// </summary>
+    public static readonly Color Error = Color.Red;
+}

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using WinUI.Controls.IBKS;
+using WinUI.Helpers;
 using WinUI.Models;
 using WinUI.Services;
 
@@ -15,11 +11,24 @@ namespace WinUI.Pages
     public partial class HomePage : UserControl
     {
         private readonly IPlcDataService _plcService;
+        private readonly List<ChannelControl> _channels;
+        private DateTime? _connectedSince;
 
         public HomePage(IPlcDataService plcService)
         {
             InitializeComponent();
             _plcService = plcService;
+            _channels = new()
+            {
+                ChannelAkm,
+                ChannelCozunmusOksijen,
+                ChannelSicaklik,
+                ChannelPh,
+                ChannelIletkenlik,
+                ChannelKoi,
+                ChannelAkisHizi,
+                ChannelDebi
+            };
         }
 
         public Task<PlcDataDto?> ReadPlcDataAsync()


### PR DESCRIPTION
## Summary
- centralize state colors for UI controls
- track PLC connection duration on HomePage
- update Channel and DigitalSensorBar colors based on PLC status

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7ecf6fe08324936148d110d123a8