### PR TITLE
Add digital sensor assignment logic

### DIFF
--- a/WinUI/Pages/HomePage.Designer.cs
+++ b/WinUI/Pages/HomePage.Designer.cs
@@ -511,6 +511,16 @@ namespace WinUI.Pages
                 ChannelKoi.InstantData              = $"{value.Analog.Koi} mg/l";
                 ChannelAkisHizi.InstantData         = $"{value.Analog.AkisHizi} mg/l";
                 ChannelDebi.InstantData             = $"{value.Analog.Debi} mg/l";
+
+                DigitalSensorKapi.SensorState        = value.Digital.Kapi ? StateColors.Error : StateColors.Ok;
+                DigitalSensorDuman.SensorState       = value.Digital.Duman ? StateColors.Error : StateColors.Ok;
+                DigitalSensorSuBaskini.SensorState   = value.Digital.SuBaskini ? StateColors.Error : StateColors.Ok;
+                DigitalSensorPompa2Termik.SensorState = value.Digital.Pompa2Termik ? StateColors.Error : StateColors.Ok;
+                DigitalSensorPompa1Termik.SensorState = value.Digital.Pompa1Termik ? StateColors.Error : StateColors.Ok;
+                DigitalSensorAcilStop.SensorState    = value.Digital.AcilStop ? StateColors.Error : StateColors.Ok;
+                DigitalSensorTSuPompaTermik.SensorState = value.Digital.TemizSuTermik ? StateColors.Error : StateColors.Ok;
+                DigitalSensorYikamaTanki.SensorState = value.Digital.YikamaTanki ? StateColors.Error : StateColors.Ok;
+                DigitalSensorEnerji.SensorState      = value.Digital.Enerji ? StateColors.Error : StateColors.Ok;
                 StatusBarControl.SistemSaati        = $"Sistem Saati: {value.TimeParameter.SystemTime:g}";
                 StatusBarControl.GunlukYikamaKalan  =
                     $"G. Yıkamaya Kalan: {value.TimeParameter.DailyWashHour:D2}:{value.TimeParameter.Minute:D2}:{value.TimeParameter.Second:D2}";
@@ -533,6 +543,8 @@ namespace WinUI.Pages
             {
                 foreach (var ch in _channels)
                     ch.ChannelStatement = _connectedSince.HasValue ? StateColors.Error : StateColors.Waiting;
+                foreach (var sensor in _digitalSensors)
+                    sensor.SensorState = _connectedSince.HasValue ? StateColors.Error : StateColors.Waiting;
 
                 digitalSensorBar1.SystemStateDescription = "HATA";
                 digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -12,6 +12,7 @@ namespace WinUI.Pages
     {
         private readonly IPlcDataService _plcService;
         private readonly List<ChannelControl> _channels;
+        private readonly List<DigitalSensorControl> _digitalSensors;
         private DateTime? _connectedSince;
 
         public HomePage(IPlcDataService plcService)
@@ -28,6 +29,18 @@ namespace WinUI.Pages
                 ChannelKoi,
                 ChannelAkisHizi,
                 ChannelDebi
+            };
+            _digitalSensors = new()
+            {
+                DigitalSensorKapi,
+                DigitalSensorDuman,
+                DigitalSensorSuBaskini,
+                DigitalSensorPompa2Termik,
+                DigitalSensorPompa1Termik,
+                DigitalSensorAcilStop,
+                DigitalSensorTSuPompaTermik,
+                DigitalSensorYikamaTanki,
+                DigitalSensorEnerji
             };
         }
 


### PR DESCRIPTION
## Summary
- wire up `DigitalSensorDataDto` values to HomePage controls
- track digital sensors with a list in `HomePage`
- set sensor colors using `StateColors`

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8d6778cc832496fcaacecbc38f4a