### PR TITLE
Refactor control naming across settings pages

### DIFF
--- a/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
@@ -28,56 +28,56 @@
         /// </summary>
         private void InitializeComponent()
         {
-            label4 = new Label();
-            textBox1 = new TextBox();
+            ApiUrlLabel = new Label();
+            ApiUrlTextBox = new TextBox();
             StationInfoContentTableLayoutPanel = new TableLayoutPanel();
-            label5 = new Label();
-            label6 = new Label();
-            textBox2 = new TextBox();
-            textBox3 = new TextBox();
+            ApiUsernameLabel = new Label();
+            ApiPasswordLabel = new Label();
+            ApiUsernameTextBox = new TextBox();
+            ApiPasswordTextBox = new TextBox();
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
-            label1 = new Label();
-            FetchButton = new Button();
-            tableLayoutPanel4 = new TableLayoutPanel();
+            ApiSettingsLabel = new Label();
+            SaveApiSettingsButton = new Button();
+            ApiSettingsHeaderTableLayoutPanel = new TableLayoutPanel();
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
-            label8 = new Label();
-            tableLayoutPanel1 = new TableLayoutPanel();
-            tableLayoutPanel2 = new TableLayoutPanel();
-            button1 = new Button();
-            button2 = new Button();
-            button3 = new Button();
-            button4 = new Button();
-            groupBox1 = new GroupBox();
-            textBox4 = new TextBox();
+            ApiTestLabel = new Label();
+            ApiTestBgTableLayoutPanel = new TableLayoutPanel();
+            ApiTestContentTableLayoutPanel = new TableLayoutPanel();
+            SendServerRequestButton = new Button();
+            LoginButton = new Button();
+            RequestSampleButton = new Button();
+            SendDiagnosticButton = new Button();
+            ResponseGroupBox = new GroupBox();
+            ResponseTextBox = new TextBox();
             StationInfoContentTableLayoutPanel.SuspendLayout();
             StationInfoBgTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel4.SuspendLayout();
+            ApiSettingsHeaderTableLayoutPanel.SuspendLayout();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel1.SuspendLayout();
-            tableLayoutPanel2.SuspendLayout();
-            groupBox1.SuspendLayout();
+            ApiTestBgTableLayoutPanel.SuspendLayout();
+            ApiTestContentTableLayoutPanel.SuspendLayout();
+            ResponseGroupBox.SuspendLayout();
             SuspendLayout();
             // 
-            // label4
+            // ApiUrlLabel
             // 
-            label4.Anchor = AnchorStyles.Left;
-            label4.AutoSize = true;
-            label4.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label4.ForeColor = Color.FromArgb(64, 64, 64);
-            label4.Location = new Point(18, 22);
-            label4.Name = "label4";
-            label4.Size = new Size(59, 16);
-            label4.TabIndex = 1;
-            label4.Text = "API URL";
+            ApiUrlLabel.Anchor = AnchorStyles.Left;
+            ApiUrlLabel.AutoSize = true;
+            ApiUrlLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ApiUrlLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ApiUrlLabel.Location = new Point(18, 22);
+            ApiUrlLabel.Name = "ApiUrlLabel";
+            ApiUrlLabel.Size = new Size(59, 16);
+            ApiUrlLabel.TabIndex = 1;
+            ApiUrlLabel.Text = "API URL";
             // 
-            // textBox1
+            // ApiUrlTextBox
             // 
-            textBox1.Anchor = AnchorStyles.Left;
-            textBox1.Location = new Point(234, 19);
-            textBox1.Name = "textBox1";
-            textBox1.PlaceholderText = "localhost";
-            textBox1.Size = new Size(288, 23);
-            textBox1.TabIndex = 2;
+            ApiUrlTextBox.Anchor = AnchorStyles.Left;
+            ApiUrlTextBox.Location = new Point(234, 19);
+            ApiUrlTextBox.Name = "ApiUrlTextBox";
+            ApiUrlTextBox.PlaceholderText = "localhost";
+            ApiUrlTextBox.Size = new Size(288, 23);
+            ApiUrlTextBox.TabIndex = 2;
             // 
             // StationInfoContentTableLayoutPanel
             // 
@@ -86,12 +86,12 @@
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationInfoContentTableLayoutPanel.Controls.Add(label4, 0, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox1, 1, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(label5, 0, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(label6, 0, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox2, 1, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox3, 1, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiUrlLabel, 0, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiUrlTextBox, 1, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiUsernameLabel, 0, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiPasswordLabel, 0, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiUsernameTextBox, 1, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(ApiPasswordTextBox, 1, 2);
             StationInfoContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoContentTableLayoutPanel.Location = new Point(1, 1);
             StationInfoContentTableLayoutPanel.Margin = new Padding(1);
@@ -115,47 +115,47 @@
             StationInfoContentTableLayoutPanel.Size = new Size(540, 461);
             StationInfoContentTableLayoutPanel.TabIndex = 2;
             // 
-            // label5
+            // ApiUsernameLabel
             // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label5.ForeColor = Color.FromArgb(64, 64, 64);
-            label5.Location = new Point(18, 53);
-            label5.Name = "label5";
-            label5.Size = new Size(114, 16);
-            label5.TabIndex = 1;
-            label5.Text = "API Kullanıcı Adı";
+            ApiUsernameLabel.Anchor = AnchorStyles.Left;
+            ApiUsernameLabel.AutoSize = true;
+            ApiUsernameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ApiUsernameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ApiUsernameLabel.Location = new Point(18, 53);
+            ApiUsernameLabel.Name = "ApiUsernameLabel";
+            ApiUsernameLabel.Size = new Size(114, 16);
+            ApiUsernameLabel.TabIndex = 1;
+            ApiUsernameLabel.Text = "API Kullanıcı Adı";
             // 
-            // label6
+            // ApiPasswordLabel
             // 
-            label6.Anchor = AnchorStyles.Left;
-            label6.AutoSize = true;
-            label6.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label6.ForeColor = Color.FromArgb(64, 64, 64);
-            label6.Location = new Point(18, 84);
-            label6.Name = "label6";
-            label6.Size = new Size(133, 16);
-            label6.TabIndex = 1;
-            label6.Text = "API Kullanıcı Şifresi";
+            ApiPasswordLabel.Anchor = AnchorStyles.Left;
+            ApiPasswordLabel.AutoSize = true;
+            ApiPasswordLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ApiPasswordLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ApiPasswordLabel.Location = new Point(18, 84);
+            ApiPasswordLabel.Name = "ApiPasswordLabel";
+            ApiPasswordLabel.Size = new Size(133, 16);
+            ApiPasswordLabel.TabIndex = 1;
+            ApiPasswordLabel.Text = "API Kullanıcı Şifresi";
             // 
-            // textBox2
+            // ApiUsernameTextBox
             // 
-            textBox2.Anchor = AnchorStyles.Left;
-            textBox2.Location = new Point(234, 50);
-            textBox2.Name = "textBox2";
-            textBox2.PlaceholderText = "api_user";
-            textBox2.Size = new Size(288, 23);
-            textBox2.TabIndex = 2;
+            ApiUsernameTextBox.Anchor = AnchorStyles.Left;
+            ApiUsernameTextBox.Location = new Point(234, 50);
+            ApiUsernameTextBox.Name = "ApiUsernameTextBox";
+            ApiUsernameTextBox.PlaceholderText = "api_user";
+            ApiUsernameTextBox.Size = new Size(288, 23);
+            ApiUsernameTextBox.TabIndex = 2;
             // 
-            // textBox3
+            // ApiPasswordTextBox
             // 
-            textBox3.Anchor = AnchorStyles.Left;
-            textBox3.Location = new Point(234, 81);
-            textBox3.Name = "textBox3";
-            textBox3.PlaceholderText = "api_pass";
-            textBox3.Size = new Size(288, 23);
-            textBox3.TabIndex = 2;
+            ApiPasswordTextBox.Anchor = AnchorStyles.Left;
+            ApiPasswordTextBox.Location = new Point(234, 81);
+            ApiPasswordTextBox.Name = "ApiPasswordTextBox";
+            ApiPasswordTextBox.PlaceholderText = "api_pass";
+            ApiPasswordTextBox.Size = new Size(288, 23);
+            ApiPasswordTextBox.TabIndex = 2;
             // 
             // StationInfoBgTableLayoutPanel
             // 
@@ -172,52 +172,52 @@
             StationInfoBgTableLayoutPanel.Size = new Size(542, 463);
             StationInfoBgTableLayoutPanel.TabIndex = 5;
             // 
-            // label1
+            // ApiSettingsLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(116, 22);
-            label1.TabIndex = 0;
-            label1.Text = "API Ayarları";
+            ApiSettingsLabel.AutoSize = true;
+            ApiSettingsLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ApiSettingsLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ApiSettingsLabel.Location = new Point(3, 0);
+            ApiSettingsLabel.Name = "ApiSettingsLabel";
+            ApiSettingsLabel.Size = new Size(116, 22);
+            ApiSettingsLabel.TabIndex = 0;
+            ApiSettingsLabel.Text = "API Ayarları";
             // 
-            // FetchButton
+            // SaveApiSettingsButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(452, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Kaydet";
-            FetchButton.UseVisualStyleBackColor = true;
+            SaveApiSettingsButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveApiSettingsButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveApiSettingsButton.Location = new Point(452, 3);
+            SaveApiSettingsButton.Name = "SaveApiSettingsButton";
+            SaveApiSettingsButton.Size = new Size(92, 32);
+            SaveApiSettingsButton.TabIndex = 2;
+            SaveApiSettingsButton.Text = "Kaydet";
+            SaveApiSettingsButton.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel4
+            // ApiSettingsHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 2;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Controls.Add(FetchButton, 1, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            ApiSettingsHeaderTableLayoutPanel.ColumnCount = 2;
+            ApiSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            ApiSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            ApiSettingsHeaderTableLayoutPanel.Controls.Add(ApiSettingsLabel, 0, 0);
+            ApiSettingsHeaderTableLayoutPanel.Controls.Add(SaveApiSettingsButton, 1, 0);
+            ApiSettingsHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            ApiSettingsHeaderTableLayoutPanel.Location = new Point(0, 0);
+            ApiSettingsHeaderTableLayoutPanel.Margin = new Padding(0);
+            ApiSettingsHeaderTableLayoutPanel.Name = "ApiSettingsHeaderTableLayoutPanel";
+            ApiSettingsHeaderTableLayoutPanel.RowCount = 1;
+            ApiSettingsHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            ApiSettingsHeaderTableLayoutPanel.Size = new Size(547, 40);
+            ApiSettingsHeaderTableLayoutPanel.TabIndex = 3;
             // 
             // StationSettingsBgTableLayoutPanel
             // 
             StationSettingsBgTableLayoutPanel.ColumnCount = 2;
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            StationSettingsBgTableLayoutPanel.Controls.Add(label8, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel1, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(ApiTestLabel, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(ApiTestBgTableLayoutPanel, 1, 1);
+            StationSettingsBgTableLayoutPanel.Controls.Add(ApiSettingsHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -228,139 +228,139 @@
             StationSettingsBgTableLayoutPanel.Size = new Size(1094, 503);
             StationSettingsBgTableLayoutPanel.TabIndex = 2;
             // 
-            // label8
+            // ApiTestLabel
             // 
-            label8.AutoSize = true;
-            label8.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label8.ForeColor = Color.FromArgb(64, 64, 64);
-            label8.Location = new Point(550, 0);
-            label8.Name = "label8";
-            label8.Size = new Size(91, 22);
-            label8.TabIndex = 0;
-            label8.Text = "API Testi";
+            ApiTestLabel.AutoSize = true;
+            ApiTestLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ApiTestLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ApiTestLabel.Location = new Point(550, 0);
+            ApiTestLabel.Name = "ApiTestLabel";
+            ApiTestLabel.Size = new Size(91, 22);
+            ApiTestLabel.TabIndex = 0;
+            ApiTestLabel.Text = "API Testi";
             // 
-            // tableLayoutPanel1
+            // ApiTestBgTableLayoutPanel
             // 
-            tableLayoutPanel1.BackColor = Color.FromArgb(235, 235, 235);
-            tableLayoutPanel1.ColumnCount = 1;
-            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Controls.Add(tableLayoutPanel2, 0, 0);
-            tableLayoutPanel1.Dock = DockStyle.Fill;
-            tableLayoutPanel1.Location = new Point(547, 40);
-            tableLayoutPanel1.Margin = new Padding(0, 0, 5, 0);
-            tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.RowCount = 1;
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Size = new Size(542, 463);
-            tableLayoutPanel1.TabIndex = 6;
+            ApiTestBgTableLayoutPanel.BackColor = Color.FromArgb(235, 235, 235);
+            ApiTestBgTableLayoutPanel.ColumnCount = 1;
+            ApiTestBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            ApiTestBgTableLayoutPanel.Controls.Add(ApiTestContentTableLayoutPanel, 0, 0);
+            ApiTestBgTableLayoutPanel.Dock = DockStyle.Fill;
+            ApiTestBgTableLayoutPanel.Location = new Point(547, 40);
+            ApiTestBgTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
+            ApiTestBgTableLayoutPanel.Name = "ApiTestBgTableLayoutPanel";
+            ApiTestBgTableLayoutPanel.RowCount = 1;
+            ApiTestBgTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            ApiTestBgTableLayoutPanel.Size = new Size(542, 463);
+            ApiTestBgTableLayoutPanel.TabIndex = 6;
             // 
-            // tableLayoutPanel2
+            // ApiTestContentTableLayoutPanel
             // 
-            tableLayoutPanel2.BackColor = Color.White;
-            tableLayoutPanel2.ColumnCount = 2;
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 36.27451F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 63.72549F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel2.Controls.Add(button1, 0, 0);
-            tableLayoutPanel2.Controls.Add(button2, 0, 1);
-            tableLayoutPanel2.Controls.Add(button3, 0, 2);
-            tableLayoutPanel2.Controls.Add(button4, 0, 3);
-            tableLayoutPanel2.Controls.Add(groupBox1, 1, 0);
-            tableLayoutPanel2.Dock = DockStyle.Fill;
-            tableLayoutPanel2.Location = new Point(1, 1);
-            tableLayoutPanel2.Margin = new Padding(1);
-            tableLayoutPanel2.Name = "tableLayoutPanel2";
-            tableLayoutPanel2.Padding = new Padding(15);
-            tableLayoutPanel2.RowCount = 14;
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.Size = new Size(540, 461);
-            tableLayoutPanel2.TabIndex = 2;
+            ApiTestContentTableLayoutPanel.BackColor = Color.White;
+            ApiTestContentTableLayoutPanel.ColumnCount = 2;
+            ApiTestContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 36.27451F));
+            ApiTestContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 63.72549F));
+            ApiTestContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+            ApiTestContentTableLayoutPanel.Controls.Add(SendServerRequestButton, 0, 0);
+            ApiTestContentTableLayoutPanel.Controls.Add(LoginButton, 0, 1);
+            ApiTestContentTableLayoutPanel.Controls.Add(RequestSampleButton, 0, 2);
+            ApiTestContentTableLayoutPanel.Controls.Add(SendDiagnosticButton, 0, 3);
+            ApiTestContentTableLayoutPanel.Controls.Add(ResponseGroupBox, 1, 0);
+            ApiTestContentTableLayoutPanel.Dock = DockStyle.Fill;
+            ApiTestContentTableLayoutPanel.Location = new Point(1, 1);
+            ApiTestContentTableLayoutPanel.Margin = new Padding(1);
+            ApiTestContentTableLayoutPanel.Name = "ApiTestContentTableLayoutPanel";
+            ApiTestContentTableLayoutPanel.Padding = new Padding(15);
+            ApiTestContentTableLayoutPanel.RowCount = 14;
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            ApiTestContentTableLayoutPanel.Size = new Size(540, 461);
+            ApiTestContentTableLayoutPanel.TabIndex = 2;
             // 
-            // button1
+            // SendServerRequestButton
             // 
-            button1.Anchor = AnchorStyles.Left;
-            button1.AutoSize = true;
-            button1.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button1.Location = new Point(18, 18);
-            button1.Name = "button1";
-            button1.Size = new Size(176, 25);
-            button1.TabIndex = 2;
-            button1.Text = "Sunucuya İstek At";
-            button1.UseVisualStyleBackColor = true;
+            SendServerRequestButton.Anchor = AnchorStyles.Left;
+            SendServerRequestButton.AutoSize = true;
+            SendServerRequestButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SendServerRequestButton.Location = new Point(18, 18);
+            SendServerRequestButton.Name = "SendServerRequestButton";
+            SendServerRequestButton.Size = new Size(176, 25);
+            SendServerRequestButton.TabIndex = 2;
+            SendServerRequestButton.Text = "Sunucuya İstek At";
+            SendServerRequestButton.UseVisualStyleBackColor = true;
             // 
-            // button2
+            // LoginButton
             // 
-            button2.Anchor = AnchorStyles.Left;
-            button2.AutoSize = true;
-            button2.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button2.Location = new Point(18, 49);
-            button2.Name = "button2";
-            button2.Size = new Size(176, 25);
-            button2.TabIndex = 2;
-            button2.Text = "Giriş Yap";
-            button2.UseVisualStyleBackColor = true;
+            LoginButton.Anchor = AnchorStyles.Left;
+            LoginButton.AutoSize = true;
+            LoginButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            LoginButton.Location = new Point(18, 49);
+            LoginButton.Name = "LoginButton";
+            LoginButton.Size = new Size(176, 25);
+            LoginButton.TabIndex = 2;
+            LoginButton.Text = "Giriş Yap";
+            LoginButton.UseVisualStyleBackColor = true;
             // 
-            // button3
+            // RequestSampleButton
             // 
-            button3.Anchor = AnchorStyles.Left;
-            button3.AutoSize = true;
-            button3.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button3.Location = new Point(18, 80);
-            button3.Name = "button3";
-            button3.Size = new Size(176, 25);
-            button3.TabIndex = 2;
-            button3.Text = "Numune Aldır";
-            button3.UseVisualStyleBackColor = true;
+            RequestSampleButton.Anchor = AnchorStyles.Left;
+            RequestSampleButton.AutoSize = true;
+            RequestSampleButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            RequestSampleButton.Location = new Point(18, 80);
+            RequestSampleButton.Name = "RequestSampleButton";
+            RequestSampleButton.Size = new Size(176, 25);
+            RequestSampleButton.TabIndex = 2;
+            RequestSampleButton.Text = "Numune Aldır";
+            RequestSampleButton.UseVisualStyleBackColor = true;
             // 
-            // button4
+            // SendDiagnosticButton
             // 
-            button4.Anchor = AnchorStyles.Left;
-            button4.AutoSize = true;
-            button4.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button4.Location = new Point(18, 111);
-            button4.Name = "button4";
-            button4.Size = new Size(176, 25);
-            button4.TabIndex = 2;
-            button4.Text = "Deneme Diagnostik Gönder";
-            button4.UseVisualStyleBackColor = true;
+            SendDiagnosticButton.Anchor = AnchorStyles.Left;
+            SendDiagnosticButton.AutoSize = true;
+            SendDiagnosticButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SendDiagnosticButton.Location = new Point(18, 111);
+            SendDiagnosticButton.Name = "SendDiagnosticButton";
+            SendDiagnosticButton.Size = new Size(176, 25);
+            SendDiagnosticButton.TabIndex = 2;
+            SendDiagnosticButton.Text = "Deneme Diagnostik Gönder";
+            SendDiagnosticButton.UseVisualStyleBackColor = true;
             // 
-            // groupBox1
+            // ResponseGroupBox
             // 
-            groupBox1.Controls.Add(textBox4);
-            groupBox1.Dock = DockStyle.Fill;
-            groupBox1.Location = new Point(203, 18);
-            groupBox1.Name = "groupBox1";
-            groupBox1.Padding = new Padding(10);
-            tableLayoutPanel2.SetRowSpan(groupBox1, 14);
-            groupBox1.Size = new Size(319, 428);
-            groupBox1.TabIndex = 3;
-            groupBox1.TabStop = false;
-            groupBox1.Text = "Cevap";
+            ResponseGroupBox.Controls.Add(ResponseTextBox);
+            ResponseGroupBox.Dock = DockStyle.Fill;
+            ResponseGroupBox.Location = new Point(203, 18);
+            ResponseGroupBox.Name = "ResponseGroupBox";
+            ResponseGroupBox.Padding = new Padding(10);
+            ApiTestContentTableLayoutPanel.SetRowSpan(ResponseGroupBox, 14);
+            ResponseGroupBox.Size = new Size(319, 428);
+            ResponseGroupBox.TabIndex = 3;
+            ResponseGroupBox.TabStop = false;
+            ResponseGroupBox.Text = "Cevap";
             // 
-            // textBox4
+            // ResponseTextBox
             // 
-            textBox4.BorderStyle = BorderStyle.None;
-            textBox4.Dock = DockStyle.Fill;
-            textBox4.ForeColor = Color.FromArgb(64, 64, 64);
-            textBox4.Location = new Point(10, 26);
-            textBox4.Margin = new Padding(15, 3, 3, 3);
-            textBox4.Multiline = true;
-            textBox4.Name = "textBox4";
-            textBox4.Size = new Size(299, 392);
-            textBox4.TabIndex = 0;
+            ResponseTextBox.BorderStyle = BorderStyle.None;
+            ResponseTextBox.Dock = DockStyle.Fill;
+            ResponseTextBox.ForeColor = Color.FromArgb(64, 64, 64);
+            ResponseTextBox.Location = new Point(10, 26);
+            ResponseTextBox.Margin = new Padding(15, 3, 3, 3);
+            ResponseTextBox.Multiline = true;
+            ResponseTextBox.Name = "ResponseTextBox";
+            ResponseTextBox.Size = new Size(299, 392);
+            ResponseTextBox.TabIndex = 0;
             // 
             // ApiSettingsPage
             // 
@@ -373,40 +373,40 @@
             StationInfoContentTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.PerformLayout();
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            ApiSettingsHeaderTableLayoutPanel.ResumeLayout(false);
+            ApiSettingsHeaderTableLayoutPanel.PerformLayout();
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
             StationSettingsBgTableLayoutPanel.PerformLayout();
-            tableLayoutPanel1.ResumeLayout(false);
-            tableLayoutPanel2.ResumeLayout(false);
-            tableLayoutPanel2.PerformLayout();
-            groupBox1.ResumeLayout(false);
-            groupBox1.PerformLayout();
+            ApiTestBgTableLayoutPanel.ResumeLayout(false);
+            ApiTestContentTableLayoutPanel.ResumeLayout(false);
+            ApiTestContentTableLayoutPanel.PerformLayout();
+            ResponseGroupBox.ResumeLayout(false);
+            ResponseGroupBox.PerformLayout();
             ResumeLayout(false);
         }
 
         #endregion
 
-        private Label label4;
-        private TextBox textBox1;
+        private Label ApiUrlLabel;
+        private TextBox ApiUrlTextBox;
         private TableLayoutPanel StationInfoContentTableLayoutPanel;
-        private Label label5;
+        private Label ApiUsernameLabel;
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
-        private Label label1;
-        private Button FetchButton;
-        private TableLayoutPanel tableLayoutPanel4;
+        private Label ApiSettingsLabel;
+        private Button SaveApiSettingsButton;
+        private TableLayoutPanel ApiSettingsHeaderTableLayoutPanel;
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
-        private Label label6;
-        private TextBox textBox2;
-        private TextBox textBox3;
-        private TableLayoutPanel tableLayoutPanel1;
-        private TableLayoutPanel tableLayoutPanel2;
-        private Label label8;
-        private Button button1;
-        private Button button2;
-        private Button button3;
-        private Button button4;
-        private GroupBox groupBox1;
-        private TextBox textBox4;
+        private Label ApiPasswordLabel;
+        private TextBox ApiUsernameTextBox;
+        private TextBox ApiPasswordTextBox;
+        private TableLayoutPanel ApiTestBgTableLayoutPanel;
+        private TableLayoutPanel ApiTestContentTableLayoutPanel;
+        private Label ApiTestLabel;
+        private Button SendServerRequestButton;
+        private Button LoginButton;
+        private Button RequestSampleButton;
+        private Button SendDiagnosticButton;
+        private GroupBox ResponseGroupBox;
+        private TextBox ResponseTextBox;
     }
 }

--- a/WinUI/Pages/Settings/CalibrationSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/CalibrationSettingsPage.Designer.cs
@@ -28,145 +28,145 @@
         /// </summary>
         private void InitializeComponent()
         {
-            tableLayoutPanel1 = new TableLayoutPanel();
-            tableLayoutPanel2 = new TableLayoutPanel();
-            label19 = new Label();
-            label20 = new Label();
-            label22 = new Label();
-            label21 = new Label();
+            CalibrationValuesBgTableLayoutPanel = new TableLayoutPanel();
+            CalibrationValuesContentTableLayoutPanel = new TableLayoutPanel();
+            AkmReferenceValuesLabel = new Label();
+            AkmZeroLabel = new Label();
+            KoiZeroLabel = new Label();
+            KoiReferenceValuesLabel = new Label();
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
-            FetchButton = new Button();
-            tableLayoutPanel4 = new TableLayoutPanel();
-            label1 = new Label();
+            SaveCalibrationButton = new Button();
+            CalibrationHeaderTableLayoutPanel = new TableLayoutPanel();
+            CalibrationSettingsLabel = new Label();
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
             StationInfoContentTableLayoutPanel = new TableLayoutPanel();
-            label5 = new Label();
-            label6 = new Label();
-            label4 = new Label();
-            comboBox1 = new ComboBox();
-            label2 = new Label();
-            label3 = new Label();
-            label7 = new Label();
-            textBox1 = new TextBox();
-            textBox2 = new TextBox();
-            textBox3 = new TextBox();
-            textBox4 = new TextBox();
-            textBox5 = new TextBox();
-            tableLayoutPanel1.SuspendLayout();
-            tableLayoutPanel2.SuspendLayout();
+            PhZeroLabel = new Label();
+            PhSpanLabel = new Label();
+            PhReferenceValuesLabel = new Label();
+            PhSpanComboBox = new ComboBox();
+            ConductivityReferenceValuesLabel = new Label();
+            ConductivityZeroLabel = new Label();
+            ConductivitySpanLabel = new Label();
+            PhZeroTextBox = new TextBox();
+            ConductivityZeroTextBox = new TextBox();
+            ConductivitySpanTextBox = new TextBox();
+            AkmZeroTextBox = new TextBox();
+            KoiZeroTextBox = new TextBox();
+            CalibrationValuesBgTableLayoutPanel.SuspendLayout();
+            CalibrationValuesContentTableLayoutPanel.SuspendLayout();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel4.SuspendLayout();
+            CalibrationHeaderTableLayoutPanel.SuspendLayout();
             StationInfoBgTableLayoutPanel.SuspendLayout();
             StationInfoContentTableLayoutPanel.SuspendLayout();
             SuspendLayout();
             // 
-            // tableLayoutPanel1
+            // CalibrationValuesBgTableLayoutPanel
             // 
-            tableLayoutPanel1.BackColor = Color.FromArgb(235, 235, 235);
-            tableLayoutPanel1.ColumnCount = 1;
-            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Controls.Add(tableLayoutPanel2, 0, 0);
-            tableLayoutPanel1.Dock = DockStyle.Fill;
-            tableLayoutPanel1.Location = new Point(547, 40);
-            tableLayoutPanel1.Margin = new Padding(0, 0, 5, 0);
-            tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.RowCount = 1;
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Size = new Size(542, 463);
-            tableLayoutPanel1.TabIndex = 6;
+            CalibrationValuesBgTableLayoutPanel.BackColor = Color.FromArgb(235, 235, 235);
+            CalibrationValuesBgTableLayoutPanel.ColumnCount = 1;
+            CalibrationValuesBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            CalibrationValuesBgTableLayoutPanel.Controls.Add(CalibrationValuesContentTableLayoutPanel, 0, 0);
+            CalibrationValuesBgTableLayoutPanel.Dock = DockStyle.Fill;
+            CalibrationValuesBgTableLayoutPanel.Location = new Point(547, 40);
+            CalibrationValuesBgTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
+            CalibrationValuesBgTableLayoutPanel.Name = "CalibrationValuesBgTableLayoutPanel";
+            CalibrationValuesBgTableLayoutPanel.RowCount = 1;
+            CalibrationValuesBgTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            CalibrationValuesBgTableLayoutPanel.Size = new Size(542, 463);
+            CalibrationValuesBgTableLayoutPanel.TabIndex = 6;
             // 
-            // tableLayoutPanel2
+            // CalibrationValuesContentTableLayoutPanel
             // 
-            tableLayoutPanel2.BackColor = Color.White;
-            tableLayoutPanel2.ColumnCount = 2;
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel2.Controls.Add(label19, 0, 0);
-            tableLayoutPanel2.Controls.Add(label20, 0, 1);
-            tableLayoutPanel2.Controls.Add(label22, 0, 5);
-            tableLayoutPanel2.Controls.Add(label21, 0, 4);
-            tableLayoutPanel2.Controls.Add(textBox4, 1, 1);
-            tableLayoutPanel2.Controls.Add(textBox5, 1, 5);
-            tableLayoutPanel2.Dock = DockStyle.Fill;
-            tableLayoutPanel2.Location = new Point(1, 1);
-            tableLayoutPanel2.Margin = new Padding(1);
-            tableLayoutPanel2.Name = "tableLayoutPanel2";
-            tableLayoutPanel2.Padding = new Padding(15);
-            tableLayoutPanel2.RowCount = 14;
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.Size = new Size(540, 461);
-            tableLayoutPanel2.TabIndex = 3;
+            CalibrationValuesContentTableLayoutPanel.BackColor = Color.White;
+            CalibrationValuesContentTableLayoutPanel.ColumnCount = 2;
+            CalibrationValuesContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
+            CalibrationValuesContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
+            CalibrationValuesContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(AkmReferenceValuesLabel, 0, 0);
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(AkmZeroLabel, 0, 1);
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(KoiZeroLabel, 0, 5);
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(KoiReferenceValuesLabel, 0, 4);
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(AkmZeroTextBox, 1, 1);
+            CalibrationValuesContentTableLayoutPanel.Controls.Add(KoiZeroTextBox, 1, 5);
+            CalibrationValuesContentTableLayoutPanel.Dock = DockStyle.Fill;
+            CalibrationValuesContentTableLayoutPanel.Location = new Point(1, 1);
+            CalibrationValuesContentTableLayoutPanel.Margin = new Padding(1);
+            CalibrationValuesContentTableLayoutPanel.Name = "CalibrationValuesContentTableLayoutPanel";
+            CalibrationValuesContentTableLayoutPanel.Padding = new Padding(15);
+            CalibrationValuesContentTableLayoutPanel.RowCount = 14;
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            CalibrationValuesContentTableLayoutPanel.Size = new Size(540, 461);
+            CalibrationValuesContentTableLayoutPanel.TabIndex = 3;
             // 
-            // label19
+            // AkmReferenceValuesLabel
             // 
-            label19.Anchor = AnchorStyles.Left;
-            label19.AutoSize = true;
-            label19.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label19.ForeColor = Color.FromArgb(64, 64, 64);
-            label19.Location = new Point(18, 22);
-            label19.Name = "label19";
-            label19.Size = new Size(159, 16);
-            label19.TabIndex = 1;
-            label19.Text = "AKM Referans Değerleri";
+            AkmReferenceValuesLabel.Anchor = AnchorStyles.Left;
+            AkmReferenceValuesLabel.AutoSize = true;
+            AkmReferenceValuesLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            AkmReferenceValuesLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            AkmReferenceValuesLabel.Location = new Point(18, 22);
+            AkmReferenceValuesLabel.Name = "AkmReferenceValuesLabel";
+            AkmReferenceValuesLabel.Size = new Size(159, 16);
+            AkmReferenceValuesLabel.TabIndex = 1;
+            AkmReferenceValuesLabel.Text = "AKM Referans Değerleri";
             // 
-            // label20
+            // AkmZeroLabel
             // 
-            label20.Anchor = AnchorStyles.Left;
-            label20.AutoSize = true;
-            label20.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label20.ForeColor = Color.FromArgb(64, 64, 64);
-            label20.Location = new Point(18, 53);
-            label20.Name = "label20";
-            label20.Size = new Size(68, 16);
-            label20.TabIndex = 1;
-            label20.Text = "AKM Zero";
+            AkmZeroLabel.Anchor = AnchorStyles.Left;
+            AkmZeroLabel.AutoSize = true;
+            AkmZeroLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            AkmZeroLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            AkmZeroLabel.Location = new Point(18, 53);
+            AkmZeroLabel.Name = "AkmZeroLabel";
+            AkmZeroLabel.Size = new Size(68, 16);
+            AkmZeroLabel.TabIndex = 1;
+            AkmZeroLabel.Text = "AKM Zero";
             // 
-            // label22
+            // KoiZeroLabel
             // 
-            label22.Anchor = AnchorStyles.Left;
-            label22.AutoSize = true;
-            label22.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label22.ForeColor = Color.FromArgb(64, 64, 64);
-            label22.Location = new Point(18, 177);
-            label22.Name = "label22";
-            label22.Size = new Size(62, 16);
-            label22.TabIndex = 1;
-            label22.Text = "KOi Zero";
+            KoiZeroLabel.Anchor = AnchorStyles.Left;
+            KoiZeroLabel.AutoSize = true;
+            KoiZeroLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            KoiZeroLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            KoiZeroLabel.Location = new Point(18, 177);
+            KoiZeroLabel.Name = "KoiZeroLabel";
+            KoiZeroLabel.Size = new Size(62, 16);
+            KoiZeroLabel.TabIndex = 1;
+            KoiZeroLabel.Text = "KOi Zero";
             // 
-            // label21
+            // KoiReferenceValuesLabel
             // 
-            label21.Anchor = AnchorStyles.Left;
-            label21.AutoSize = true;
-            label21.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label21.ForeColor = Color.FromArgb(64, 64, 64);
-            label21.Location = new Point(18, 146);
-            label21.Name = "label21";
-            label21.Size = new Size(153, 16);
-            label21.TabIndex = 1;
-            label21.Text = "KOi Referans Değerleri";
+            KoiReferenceValuesLabel.Anchor = AnchorStyles.Left;
+            KoiReferenceValuesLabel.AutoSize = true;
+            KoiReferenceValuesLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            KoiReferenceValuesLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            KoiReferenceValuesLabel.Location = new Point(18, 146);
+            KoiReferenceValuesLabel.Name = "KoiReferenceValuesLabel";
+            KoiReferenceValuesLabel.Size = new Size(153, 16);
+            KoiReferenceValuesLabel.TabIndex = 1;
+            KoiReferenceValuesLabel.Text = "KOi Referans Değerleri";
             // 
             // StationSettingsBgTableLayoutPanel
             // 
             StationSettingsBgTableLayoutPanel.ColumnCount = 2;
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel1, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(FetchButton, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(CalibrationValuesBgTableLayoutPanel, 1, 1);
+            StationSettingsBgTableLayoutPanel.Controls.Add(SaveCalibrationButton, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(CalibrationHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -177,42 +177,42 @@
             StationSettingsBgTableLayoutPanel.Size = new Size(1094, 503);
             StationSettingsBgTableLayoutPanel.TabIndex = 3;
             // 
-            // FetchButton
+            // SaveCalibrationButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(999, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Kaydet";
-            FetchButton.UseVisualStyleBackColor = true;
+            SaveCalibrationButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveCalibrationButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveCalibrationButton.Location = new Point(999, 3);
+            SaveCalibrationButton.Name = "SaveCalibrationButton";
+            SaveCalibrationButton.Size = new Size(92, 32);
+            SaveCalibrationButton.TabIndex = 2;
+            SaveCalibrationButton.Text = "Kaydet";
+            SaveCalibrationButton.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel4
+            // CalibrationHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 2;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            CalibrationHeaderTableLayoutPanel.ColumnCount = 2;
+            CalibrationHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            CalibrationHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            CalibrationHeaderTableLayoutPanel.Controls.Add(CalibrationSettingsLabel, 0, 0);
+            CalibrationHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            CalibrationHeaderTableLayoutPanel.Location = new Point(0, 0);
+            CalibrationHeaderTableLayoutPanel.Margin = new Padding(0);
+            CalibrationHeaderTableLayoutPanel.Name = "CalibrationHeaderTableLayoutPanel";
+            CalibrationHeaderTableLayoutPanel.RowCount = 1;
+            CalibrationHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            CalibrationHeaderTableLayoutPanel.Size = new Size(547, 40);
+            CalibrationHeaderTableLayoutPanel.TabIndex = 3;
             // 
-            // label1
+            // CalibrationSettingsLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(197, 22);
-            label1.TabIndex = 0;
-            label1.Text = "Kalibrasyon Ayarları";
+            CalibrationSettingsLabel.AutoSize = true;
+            CalibrationSettingsLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CalibrationSettingsLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CalibrationSettingsLabel.Location = new Point(3, 0);
+            CalibrationSettingsLabel.Name = "CalibrationSettingsLabel";
+            CalibrationSettingsLabel.Size = new Size(197, 22);
+            CalibrationSettingsLabel.TabIndex = 0;
+            CalibrationSettingsLabel.Text = "Kalibrasyon Ayarları";
             // 
             // StationInfoBgTableLayoutPanel
             // 
@@ -236,16 +236,16 @@
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationInfoContentTableLayoutPanel.Controls.Add(label5, 0, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(label6, 0, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(label4, 0, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(comboBox1, 1, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(label2, 0, 4);
-            StationInfoContentTableLayoutPanel.Controls.Add(label3, 0, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(label7, 0, 6);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox1, 1, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox2, 1, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox3, 1, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(PhZeroLabel, 0, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(PhSpanLabel, 0, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(PhReferenceValuesLabel, 0, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(PhSpanComboBox, 1, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(ConductivityReferenceValuesLabel, 0, 4);
+            StationInfoContentTableLayoutPanel.Controls.Add(ConductivityZeroLabel, 0, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(ConductivitySpanLabel, 0, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(PhZeroTextBox, 1, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(ConductivityZeroTextBox, 1, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(ConductivitySpanTextBox, 1, 6);
             StationInfoContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoContentTableLayoutPanel.Location = new Point(1, 1);
             StationInfoContentTableLayoutPanel.Margin = new Padding(1);
@@ -269,143 +269,143 @@
             StationInfoContentTableLayoutPanel.Size = new Size(540, 461);
             StationInfoContentTableLayoutPanel.TabIndex = 2;
             // 
-            // label5
+            // PhZeroLabel
             // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label5.ForeColor = Color.FromArgb(64, 64, 64);
-            label5.Location = new Point(18, 53);
-            label5.Name = "label5";
-            label5.Size = new Size(56, 16);
-            label5.TabIndex = 1;
-            label5.Text = "pH Zero";
+            PhZeroLabel.Anchor = AnchorStyles.Left;
+            PhZeroLabel.AutoSize = true;
+            PhZeroLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            PhZeroLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            PhZeroLabel.Location = new Point(18, 53);
+            PhZeroLabel.Name = "PhZeroLabel";
+            PhZeroLabel.Size = new Size(56, 16);
+            PhZeroLabel.TabIndex = 1;
+            PhZeroLabel.Text = "pH Zero";
             // 
-            // label6
+            // PhSpanLabel
             // 
-            label6.Anchor = AnchorStyles.Left;
-            label6.AutoSize = true;
-            label6.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label6.ForeColor = Color.FromArgb(64, 64, 64);
-            label6.Location = new Point(18, 84);
-            label6.Name = "label6";
-            label6.Size = new Size(61, 16);
-            label6.TabIndex = 1;
-            label6.Text = "pH Span";
+            PhSpanLabel.Anchor = AnchorStyles.Left;
+            PhSpanLabel.AutoSize = true;
+            PhSpanLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            PhSpanLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            PhSpanLabel.Location = new Point(18, 84);
+            PhSpanLabel.Name = "PhSpanLabel";
+            PhSpanLabel.Size = new Size(61, 16);
+            PhSpanLabel.TabIndex = 1;
+            PhSpanLabel.Text = "pH Span";
             // 
-            // label4
+            // PhReferenceValuesLabel
             // 
-            label4.Anchor = AnchorStyles.Left;
-            label4.AutoSize = true;
-            label4.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label4.ForeColor = Color.FromArgb(64, 64, 64);
-            label4.Location = new Point(18, 22);
-            label4.Name = "label4";
-            label4.Size = new Size(147, 16);
-            label4.TabIndex = 1;
-            label4.Text = "pH Referans Değerleri";
+            PhReferenceValuesLabel.Anchor = AnchorStyles.Left;
+            PhReferenceValuesLabel.AutoSize = true;
+            PhReferenceValuesLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            PhReferenceValuesLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            PhReferenceValuesLabel.Location = new Point(18, 22);
+            PhReferenceValuesLabel.Name = "PhReferenceValuesLabel";
+            PhReferenceValuesLabel.Size = new Size(147, 16);
+            PhReferenceValuesLabel.TabIndex = 1;
+            PhReferenceValuesLabel.Text = "pH Referans Değerleri";
             // 
-            // comboBox1
+            // PhSpanComboBox
             // 
-            comboBox1.DropDownStyle = ComboBoxStyle.DropDownList;
-            comboBox1.Font = new Font("Arial", 9.75F);
-            comboBox1.FormattingEnabled = true;
-            comboBox1.Items.AddRange(new object[] { "4", "10" });
-            comboBox1.Location = new Point(234, 80);
-            comboBox1.Name = "comboBox1";
-            comboBox1.Size = new Size(121, 24);
-            comboBox1.TabIndex = 3;
+            PhSpanComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            PhSpanComboBox.Font = new Font("Arial", 9.75F);
+            PhSpanComboBox.FormattingEnabled = true;
+            PhSpanComboBox.Items.AddRange(new object[] { "4", "10" });
+            PhSpanComboBox.Location = new Point(234, 80);
+            PhSpanComboBox.Name = "PhSpanComboBox";
+            PhSpanComboBox.Size = new Size(121, 24);
+            PhSpanComboBox.TabIndex = 3;
             // 
-            // label2
+            // ConductivityReferenceValuesLabel
             // 
-            label2.Anchor = AnchorStyles.Left;
-            label2.AutoSize = true;
-            label2.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label2.ForeColor = Color.FromArgb(64, 64, 64);
-            label2.Location = new Point(18, 146);
-            label2.Name = "label2";
-            label2.Size = new Size(188, 16);
-            label2.TabIndex = 1;
-            label2.Text = "İletkenlik Referans Değerleri";
+            ConductivityReferenceValuesLabel.Anchor = AnchorStyles.Left;
+            ConductivityReferenceValuesLabel.AutoSize = true;
+            ConductivityReferenceValuesLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConductivityReferenceValuesLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConductivityReferenceValuesLabel.Location = new Point(18, 146);
+            ConductivityReferenceValuesLabel.Name = "ConductivityReferenceValuesLabel";
+            ConductivityReferenceValuesLabel.Size = new Size(188, 16);
+            ConductivityReferenceValuesLabel.TabIndex = 1;
+            ConductivityReferenceValuesLabel.Text = "İletkenlik Referans Değerleri";
             // 
-            // label3
+            // ConductivityZeroLabel
             // 
-            label3.Anchor = AnchorStyles.Left;
-            label3.AutoSize = true;
-            label3.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label3.ForeColor = Color.FromArgb(64, 64, 64);
-            label3.Location = new Point(18, 177);
-            label3.Name = "label3";
-            label3.Size = new Size(97, 16);
-            label3.TabIndex = 1;
-            label3.Text = "İletkenlik Zero";
+            ConductivityZeroLabel.Anchor = AnchorStyles.Left;
+            ConductivityZeroLabel.AutoSize = true;
+            ConductivityZeroLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConductivityZeroLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConductivityZeroLabel.Location = new Point(18, 177);
+            ConductivityZeroLabel.Name = "ConductivityZeroLabel";
+            ConductivityZeroLabel.Size = new Size(97, 16);
+            ConductivityZeroLabel.TabIndex = 1;
+            ConductivityZeroLabel.Text = "İletkenlik Zero";
             // 
-            // label7
+            // ConductivitySpanLabel
             // 
-            label7.Anchor = AnchorStyles.Left;
-            label7.AutoSize = true;
-            label7.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label7.ForeColor = Color.FromArgb(64, 64, 64);
-            label7.Location = new Point(18, 208);
-            label7.Name = "label7";
-            label7.Size = new Size(102, 16);
-            label7.TabIndex = 1;
-            label7.Text = "İletkenlik Span";
+            ConductivitySpanLabel.Anchor = AnchorStyles.Left;
+            ConductivitySpanLabel.AutoSize = true;
+            ConductivitySpanLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConductivitySpanLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConductivitySpanLabel.Location = new Point(18, 208);
+            ConductivitySpanLabel.Name = "ConductivitySpanLabel";
+            ConductivitySpanLabel.Size = new Size(102, 16);
+            ConductivitySpanLabel.TabIndex = 1;
+            ConductivitySpanLabel.Text = "İletkenlik Span";
             // 
-            // textBox1
+            // PhZeroTextBox
             // 
-            textBox1.Anchor = AnchorStyles.Left;
-            textBox1.Enabled = false;
-            textBox1.Font = new Font("Arial", 9.75F);
-            textBox1.Location = new Point(234, 50);
-            textBox1.Name = "textBox1";
-            textBox1.Size = new Size(121, 22);
-            textBox1.TabIndex = 4;
-            textBox1.Text = "7";
+            PhZeroTextBox.Anchor = AnchorStyles.Left;
+            PhZeroTextBox.Enabled = false;
+            PhZeroTextBox.Font = new Font("Arial", 9.75F);
+            PhZeroTextBox.Location = new Point(234, 50);
+            PhZeroTextBox.Name = "PhZeroTextBox";
+            PhZeroTextBox.Size = new Size(121, 22);
+            PhZeroTextBox.TabIndex = 4;
+            PhZeroTextBox.Text = "7";
             // 
-            // textBox2
+            // ConductivityZeroTextBox
             // 
-            textBox2.Anchor = AnchorStyles.Left;
-            textBox2.Enabled = false;
-            textBox2.Font = new Font("Arial", 9.75F);
-            textBox2.Location = new Point(234, 174);
-            textBox2.Name = "textBox2";
-            textBox2.Size = new Size(121, 22);
-            textBox2.TabIndex = 4;
-            textBox2.Text = "0";
+            ConductivityZeroTextBox.Anchor = AnchorStyles.Left;
+            ConductivityZeroTextBox.Enabled = false;
+            ConductivityZeroTextBox.Font = new Font("Arial", 9.75F);
+            ConductivityZeroTextBox.Location = new Point(234, 174);
+            ConductivityZeroTextBox.Name = "ConductivityZeroTextBox";
+            ConductivityZeroTextBox.Size = new Size(121, 22);
+            ConductivityZeroTextBox.TabIndex = 4;
+            ConductivityZeroTextBox.Text = "0";
             // 
-            // textBox3
+            // ConductivitySpanTextBox
             // 
-            textBox3.Anchor = AnchorStyles.Left;
-            textBox3.Enabled = false;
-            textBox3.Font = new Font("Arial", 9.75F);
-            textBox3.Location = new Point(234, 205);
-            textBox3.Name = "textBox3";
-            textBox3.Size = new Size(121, 22);
-            textBox3.TabIndex = 4;
-            textBox3.Text = "1413";
+            ConductivitySpanTextBox.Anchor = AnchorStyles.Left;
+            ConductivitySpanTextBox.Enabled = false;
+            ConductivitySpanTextBox.Font = new Font("Arial", 9.75F);
+            ConductivitySpanTextBox.Location = new Point(234, 205);
+            ConductivitySpanTextBox.Name = "ConductivitySpanTextBox";
+            ConductivitySpanTextBox.Size = new Size(121, 22);
+            ConductivitySpanTextBox.TabIndex = 4;
+            ConductivitySpanTextBox.Text = "1413";
             // 
-            // textBox4
+            // AkmZeroTextBox
             // 
-            textBox4.Anchor = AnchorStyles.Left;
-            textBox4.Enabled = false;
-            textBox4.Font = new Font("Arial", 9.75F);
-            textBox4.Location = new Point(234, 50);
-            textBox4.Name = "textBox4";
-            textBox4.Size = new Size(121, 22);
-            textBox4.TabIndex = 4;
-            textBox4.Text = "0";
+            AkmZeroTextBox.Anchor = AnchorStyles.Left;
+            AkmZeroTextBox.Enabled = false;
+            AkmZeroTextBox.Font = new Font("Arial", 9.75F);
+            AkmZeroTextBox.Location = new Point(234, 50);
+            AkmZeroTextBox.Name = "AkmZeroTextBox";
+            AkmZeroTextBox.Size = new Size(121, 22);
+            AkmZeroTextBox.TabIndex = 4;
+            AkmZeroTextBox.Text = "0";
             // 
-            // textBox5
+            // KoiZeroTextBox
             // 
-            textBox5.Anchor = AnchorStyles.Left;
-            textBox5.Enabled = false;
-            textBox5.Font = new Font("Arial", 9.75F);
-            textBox5.Location = new Point(234, 174);
-            textBox5.Name = "textBox5";
-            textBox5.Size = new Size(121, 22);
-            textBox5.TabIndex = 4;
-            textBox5.Text = "0";
+            KoiZeroTextBox.Anchor = AnchorStyles.Left;
+            KoiZeroTextBox.Enabled = false;
+            KoiZeroTextBox.Font = new Font("Arial", 9.75F);
+            KoiZeroTextBox.Location = new Point(234, 174);
+            KoiZeroTextBox.Name = "KoiZeroTextBox";
+            KoiZeroTextBox.Size = new Size(121, 22);
+            KoiZeroTextBox.TabIndex = 4;
+            KoiZeroTextBox.Text = "0";
             // 
             // CalibrationSettingsPage
             // 
@@ -415,12 +415,12 @@
             Name = "CalibrationSettingsPage";
             Padding = new Padding(0, 15, 0, 15);
             Size = new Size(1094, 533);
-            tableLayoutPanel1.ResumeLayout(false);
-            tableLayoutPanel2.ResumeLayout(false);
-            tableLayoutPanel2.PerformLayout();
+            CalibrationValuesBgTableLayoutPanel.ResumeLayout(false);
+            CalibrationValuesContentTableLayoutPanel.ResumeLayout(false);
+            CalibrationValuesContentTableLayoutPanel.PerformLayout();
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            CalibrationHeaderTableLayoutPanel.ResumeLayout(false);
+            CalibrationHeaderTableLayoutPanel.PerformLayout();
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.PerformLayout();
@@ -428,29 +428,29 @@
         }
 
         #endregion
-        private TableLayoutPanel tableLayoutPanel1;
+        private TableLayoutPanel CalibrationValuesBgTableLayoutPanel;
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
-        private TableLayoutPanel tableLayoutPanel4;
-        private Label label1;
-        private Button FetchButton;
+        private TableLayoutPanel CalibrationHeaderTableLayoutPanel;
+        private Label CalibrationSettingsLabel;
+        private Button SaveCalibrationButton;
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
-        private TableLayoutPanel tableLayoutPanel2;
-        private Label label19;
-        private Label label20;
-        private Label label21;
-        private Label label22;
+        private TableLayoutPanel CalibrationValuesContentTableLayoutPanel;
+        private Label AkmReferenceValuesLabel;
+        private Label AkmZeroLabel;
+        private Label KoiReferenceValuesLabel;
+        private Label KoiZeroLabel;
         private TableLayoutPanel StationInfoContentTableLayoutPanel;
-        private Label label5;
-        private Label label6;
-        private Label label4;
-        private ComboBox comboBox1;
-        private Label label2;
-        private Label label3;
-        private Label label7;
-        private TextBox textBox1;
-        private TextBox textBox2;
-        private TextBox textBox3;
-        private TextBox textBox4;
-        private TextBox textBox5;
+        private Label PhZeroLabel;
+        private Label PhSpanLabel;
+        private Label PhReferenceValuesLabel;
+        private ComboBox PhSpanComboBox;
+        private Label ConductivityReferenceValuesLabel;
+        private Label ConductivityZeroLabel;
+        private Label ConductivitySpanLabel;
+        private TextBox PhZeroTextBox;
+        private TextBox ConductivityZeroTextBox;
+        private TextBox ConductivitySpanTextBox;
+        private TextBox AkmZeroTextBox;
+        private TextBox KoiZeroTextBox;
     }
 }

--- a/WinUI/Pages/Settings/ChannelSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/ChannelSettingsPage.Designer.cs
@@ -28,93 +28,93 @@
         /// </summary>
         private void InitializeComponent()
         {
-            tableLayoutPanel1 = new TableLayoutPanel();
+            UpdateChannelBgTableLayoutPanel = new TableLayoutPanel();
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
-            tableLayoutPanel4 = new TableLayoutPanel();
-            label1 = new Label();
-            FetchButton = new Button();
+            FetchChannelHeaderTableLayoutPanel = new TableLayoutPanel();
+            FetchChannelTitleLabel = new Label();
+            FetchChannelButton = new Button();
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
             StationInfoContentTableLayoutPanel = new TableLayoutPanel();
-            label4 = new Label();
-            label5 = new Label();
-            label6 = new Label();
-            comboBox1 = new ComboBox();
-            label2 = new Label();
-            label3 = new Label();
-            label7 = new Label();
-            label9 = new Label();
-            label10 = new Label();
-            label11 = new Label();
-            label12 = new Label();
-            label13 = new Label();
-            label14 = new Label();
-            label15 = new Label();
-            label16 = new Label();
-            label17 = new Label();
-            textBox3 = new TextBox();
-            textBox1 = new TextBox();
-            textBox2 = new TextBox();
-            textBox5 = new TextBox();
-            textBox6 = new TextBox();
-            textBox7 = new TextBox();
-            textBox8 = new TextBox();
-            textBox9 = new TextBox();
-            textBox10 = new TextBox();
-            textBox11 = new TextBox();
-            textBox12 = new TextBox();
-            textBox13 = new TextBox();
-            textBox14 = new TextBox();
-            textBox15 = new TextBox();
-            tableLayoutPanel2 = new TableLayoutPanel();
-            label18 = new Label();
-            label19 = new Label();
-            label20 = new Label();
-            label21 = new Label();
-            label22 = new Label();
-            label23 = new Label();
-            label24 = new Label();
-            textBox4 = new TextBox();
-            textBox16 = new TextBox();
-            textBox17 = new TextBox();
-            textBox18 = new TextBox();
-            textBox19 = new TextBox();
-            textBox20 = new TextBox();
-            textBox21 = new TextBox();
-            tableLayoutPanel3 = new TableLayoutPanel();
-            label32 = new Label();
-            button1 = new Button();
-            tableLayoutPanel1.SuspendLayout();
+            BrandLabel = new Label();
+            BrandModelLabel = new Label();
+            FullNameLabel = new Label();
+            ChannelComboBox = new ComboBox();
+            ChannelLabel = new Label();
+            ParameterLabel = new Label();
+            ParameterTextLabel = new Label();
+            UnitLabel = new Label();
+            UnitTextLabel = new Label();
+            IsActiveLabel = new Label();
+            ChannelMinValueLabel = new Label();
+            ChannelMaxValueLabel = new Label();
+            ChannelNumberLabel = new Label();
+            CalibrationFormulaALabel = new Label();
+            CalibrationFormulaBLabel = new Label();
+            SerialNumberLabel = new Label();
+            FullNameTextBox = new TextBox();
+            BrandTextBox = new TextBox();
+            BrandModelTextBox = new TextBox();
+            ParameterTextBox = new TextBox();
+            ParameterTextTextBox = new TextBox();
+            UnitTextBox = new TextBox();
+            UnitTextTextBox = new TextBox();
+            IsActiveTextBox = new TextBox();
+            ChannelMinValueTextBox = new TextBox();
+            ChannelMaxValueTextBox = new TextBox();
+            ChannelNumberTextBox = new TextBox();
+            CalibrationFormulaATextBox = new TextBox();
+            CalibrationFormulaBTextBox = new TextBox();
+            SerialNumberTextBox = new TextBox();
+            UpdateChannelContentTableLayoutPanel = new TableLayoutPanel();
+            UnitUpdateLabel = new Label();
+            IsActiveUpdateLabel = new Label();
+            ChannelMinValueUpdateLabel = new Label();
+            ChannelMaxValueUpdateLabel = new Label();
+            ChannelNumberUpdateLabel = new Label();
+            CalibrationFormulaAUpdateLabel = new Label();
+            CalibrationFormulaBUpdateLabel = new Label();
+            ChannelMinValueUpdateTextBox = new TextBox();
+            UnitUpdateTextBox = new TextBox();
+            IsActiveUpdateTextBox = new TextBox();
+            ChannelMaxValueUpdateTextBox = new TextBox();
+            ChannelNumberUpdateTextBox = new TextBox();
+            CalibrationFormulaAUpdateTextBox = new TextBox();
+            CalibrationFormulaBUpdateTextBox = new TextBox();
+            UpdateChannelHeaderTableLayoutPanel = new TableLayoutPanel();
+            UpdateChannelTitleLabel = new Label();
+            SaveChannelButton = new Button();
+            UpdateChannelBgTableLayoutPanel.SuspendLayout();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel4.SuspendLayout();
+            FetchChannelHeaderTableLayoutPanel.SuspendLayout();
             StationInfoBgTableLayoutPanel.SuspendLayout();
             StationInfoContentTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel2.SuspendLayout();
-            tableLayoutPanel3.SuspendLayout();
+            UpdateChannelContentTableLayoutPanel.SuspendLayout();
+            UpdateChannelHeaderTableLayoutPanel.SuspendLayout();
             SuspendLayout();
             // 
-            // tableLayoutPanel1
+            // UpdateChannelBgTableLayoutPanel
             // 
-            tableLayoutPanel1.BackColor = Color.FromArgb(235, 235, 235);
-            tableLayoutPanel1.ColumnCount = 1;
-            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Controls.Add(tableLayoutPanel2, 0, 0);
-            tableLayoutPanel1.Dock = DockStyle.Fill;
-            tableLayoutPanel1.Location = new Point(547, 40);
-            tableLayoutPanel1.Margin = new Padding(0, 0, 5, 0);
-            tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.RowCount = 1;
-            tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel1.Size = new Size(542, 463);
-            tableLayoutPanel1.TabIndex = 6;
+            UpdateChannelBgTableLayoutPanel.BackColor = Color.FromArgb(235, 235, 235);
+            UpdateChannelBgTableLayoutPanel.ColumnCount = 1;
+            UpdateChannelBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            UpdateChannelBgTableLayoutPanel.Controls.Add(UpdateChannelContentTableLayoutPanel, 0, 0);
+            UpdateChannelBgTableLayoutPanel.Dock = DockStyle.Fill;
+            UpdateChannelBgTableLayoutPanel.Location = new Point(547, 40);
+            UpdateChannelBgTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
+            UpdateChannelBgTableLayoutPanel.Name = "UpdateChannelBgTableLayoutPanel";
+            UpdateChannelBgTableLayoutPanel.RowCount = 1;
+            UpdateChannelBgTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            UpdateChannelBgTableLayoutPanel.Size = new Size(542, 463);
+            UpdateChannelBgTableLayoutPanel.TabIndex = 6;
             // 
             // StationSettingsBgTableLayoutPanel
             // 
             StationSettingsBgTableLayoutPanel.ColumnCount = 2;
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel3, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel1, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(UpdateChannelHeaderTableLayoutPanel, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(UpdateChannelBgTableLayoutPanel, 1, 1);
+            StationSettingsBgTableLayoutPanel.Controls.Add(FetchChannelHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -126,47 +126,47 @@
             StationSettingsBgTableLayoutPanel.Size = new Size(1094, 503);
             StationSettingsBgTableLayoutPanel.TabIndex = 3;
             // 
-            // tableLayoutPanel4
+            // FetchChannelHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 4;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 200F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 60F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 141F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel4.Controls.Add(label2, 1, 0);
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Controls.Add(FetchButton, 3, 0);
-            tableLayoutPanel4.Controls.Add(comboBox1, 2, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            FetchChannelHeaderTableLayoutPanel.ColumnCount = 4;
+            FetchChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 200F));
+            FetchChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 60F));
+            FetchChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 141F));
+            FetchChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            FetchChannelHeaderTableLayoutPanel.Controls.Add(ChannelLabel, 1, 0);
+            FetchChannelHeaderTableLayoutPanel.Controls.Add(FetchChannelTitleLabel, 0, 0);
+            FetchChannelHeaderTableLayoutPanel.Controls.Add(FetchChannelButton, 3, 0);
+            FetchChannelHeaderTableLayoutPanel.Controls.Add(ChannelComboBox, 2, 0);
+            FetchChannelHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            FetchChannelHeaderTableLayoutPanel.Location = new Point(0, 0);
+            FetchChannelHeaderTableLayoutPanel.Margin = new Padding(0);
+            FetchChannelHeaderTableLayoutPanel.Name = "FetchChannelHeaderTableLayoutPanel";
+            FetchChannelHeaderTableLayoutPanel.RowCount = 1;
+            FetchChannelHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            FetchChannelHeaderTableLayoutPanel.Size = new Size(547, 40);
+            FetchChannelHeaderTableLayoutPanel.TabIndex = 3;
             // 
-            // label1
+            // FetchChannelTitleLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(188, 22);
-            label1.TabIndex = 0;
-            label1.Text = "Kanal Bilgileri Getir";
+            FetchChannelTitleLabel.AutoSize = true;
+            FetchChannelTitleLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            FetchChannelTitleLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            FetchChannelTitleLabel.Location = new Point(3, 0);
+            FetchChannelTitleLabel.Name = "FetchChannelTitleLabel";
+            FetchChannelTitleLabel.Size = new Size(188, 22);
+            FetchChannelTitleLabel.TabIndex = 0;
+            FetchChannelTitleLabel.Text = "Kanal Bilgileri Getir";
             // 
-            // FetchButton
+            // FetchChannelButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(452, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Getir";
-            FetchButton.UseVisualStyleBackColor = true;
+            FetchChannelButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            FetchChannelButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            FetchChannelButton.Location = new Point(452, 3);
+            FetchChannelButton.Name = "FetchChannelButton";
+            FetchChannelButton.Size = new Size(92, 32);
+            FetchChannelButton.TabIndex = 2;
+            FetchChannelButton.Text = "Getir";
+            FetchChannelButton.UseVisualStyleBackColor = true;
             // 
             // StationInfoBgTableLayoutPanel
             // 
@@ -190,34 +190,34 @@
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationInfoContentTableLayoutPanel.Controls.Add(label4, 0, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(label5, 0, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(label6, 0, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(label3, 0, 3);
-            StationInfoContentTableLayoutPanel.Controls.Add(label7, 0, 4);
-            StationInfoContentTableLayoutPanel.Controls.Add(label9, 0, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(label10, 0, 6);
-            StationInfoContentTableLayoutPanel.Controls.Add(label11, 0, 7);
-            StationInfoContentTableLayoutPanel.Controls.Add(label12, 0, 8);
-            StationInfoContentTableLayoutPanel.Controls.Add(label13, 0, 9);
-            StationInfoContentTableLayoutPanel.Controls.Add(label14, 0, 10);
-            StationInfoContentTableLayoutPanel.Controls.Add(label15, 0, 11);
-            StationInfoContentTableLayoutPanel.Controls.Add(label16, 0, 12);
-            StationInfoContentTableLayoutPanel.Controls.Add(label17, 0, 13);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox3, 1, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox1, 1, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox2, 1, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox5, 1, 3);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox6, 1, 4);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox7, 1, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox8, 1, 6);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox9, 1, 7);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox10, 1, 8);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox11, 1, 9);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox12, 1, 10);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox13, 1, 11);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox14, 1, 12);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox15, 1, 13);
+            StationInfoContentTableLayoutPanel.Controls.Add(BrandLabel, 0, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(BrandModelLabel, 0, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(FullNameLabel, 0, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(ParameterLabel, 0, 3);
+            StationInfoContentTableLayoutPanel.Controls.Add(ParameterTextLabel, 0, 4);
+            StationInfoContentTableLayoutPanel.Controls.Add(UnitLabel, 0, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(UnitTextLabel, 0, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(IsActiveLabel, 0, 7);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelMinValueLabel, 0, 8);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelMaxValueLabel, 0, 9);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelNumberLabel, 0, 10);
+            StationInfoContentTableLayoutPanel.Controls.Add(CalibrationFormulaALabel, 0, 11);
+            StationInfoContentTableLayoutPanel.Controls.Add(CalibrationFormulaBLabel, 0, 12);
+            StationInfoContentTableLayoutPanel.Controls.Add(SerialNumberLabel, 0, 13);
+            StationInfoContentTableLayoutPanel.Controls.Add(FullNameTextBox, 1, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(BrandTextBox, 1, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(BrandModelTextBox, 1, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(ParameterTextBox, 1, 3);
+            StationInfoContentTableLayoutPanel.Controls.Add(ParameterTextTextBox, 1, 4);
+            StationInfoContentTableLayoutPanel.Controls.Add(UnitTextBox, 1, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(UnitTextTextBox, 1, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(IsActiveTextBox, 1, 7);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelMinValueTextBox, 1, 8);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelMaxValueTextBox, 1, 9);
+            StationInfoContentTableLayoutPanel.Controls.Add(ChannelNumberTextBox, 1, 10);
+            StationInfoContentTableLayoutPanel.Controls.Add(CalibrationFormulaATextBox, 1, 11);
+            StationInfoContentTableLayoutPanel.Controls.Add(CalibrationFormulaBTextBox, 1, 12);
+            StationInfoContentTableLayoutPanel.Controls.Add(SerialNumberTextBox, 1, 13);
             StationInfoContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoContentTableLayoutPanel.Location = new Point(1, 1);
             StationInfoContentTableLayoutPanel.Margin = new Padding(1);
@@ -241,530 +241,530 @@
             StationInfoContentTableLayoutPanel.Size = new Size(540, 461);
             StationInfoContentTableLayoutPanel.TabIndex = 2;
             // 
-            // label4
-            // 
-            label4.Anchor = AnchorStyles.Left;
-            label4.AutoSize = true;
-            label4.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label4.ForeColor = Color.FromArgb(64, 64, 64);
-            label4.Location = new Point(18, 22);
-            label4.Name = "label4";
-            label4.Size = new Size(45, 16);
-            label4.TabIndex = 1;
-            label4.Text = "Brand";
-            // 
-            // label5
-            // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label5.ForeColor = Color.FromArgb(64, 64, 64);
-            label5.Location = new Point(18, 53);
-            label5.Name = "label5";
-            label5.Size = new Size(84, 16);
-            label5.TabIndex = 1;
-            label5.Text = "BrandModel";
-            // 
-            // label6
-            // 
-            label6.Anchor = AnchorStyles.Left;
-            label6.AutoSize = true;
-            label6.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label6.ForeColor = Color.FromArgb(64, 64, 64);
-            label6.Location = new Point(18, 84);
-            label6.Name = "label6";
-            label6.Size = new Size(68, 16);
-            label6.TabIndex = 1;
-            label6.Text = "FullName";
-            // 
-            // comboBox1
-            // 
-            comboBox1.Anchor = AnchorStyles.Left;
-            comboBox1.FormattingEnabled = true;
-            comboBox1.Location = new Point(263, 8);
-            comboBox1.Name = "comboBox1";
-            comboBox1.Size = new Size(121, 23);
-            comboBox1.TabIndex = 3;
-            // 
-            // label2
-            // 
-            label2.Anchor = AnchorStyles.Left;
-            label2.AutoSize = true;
-            label2.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label2.ForeColor = Color.FromArgb(64, 64, 64);
-            label2.Location = new Point(203, 12);
-            label2.Name = "label2";
-            label2.Size = new Size(48, 16);
-            label2.TabIndex = 1;
-            label2.Text = "Kanal:";
-            // 
-            // label3
-            // 
-            label3.Anchor = AnchorStyles.Left;
-            label3.AutoSize = true;
-            label3.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label3.ForeColor = Color.FromArgb(64, 64, 64);
-            label3.Location = new Point(18, 115);
-            label3.Name = "label3";
-            label3.Size = new Size(74, 16);
-            label3.TabIndex = 1;
-            label3.Text = "Parameter";
-            // 
-            // label7
-            // 
-            label7.Anchor = AnchorStyles.Left;
-            label7.AutoSize = true;
-            label7.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label7.ForeColor = Color.FromArgb(64, 64, 64);
-            label7.Location = new Point(18, 146);
-            label7.Name = "label7";
-            label7.Size = new Size(101, 16);
-            label7.TabIndex = 1;
-            label7.Text = "ParameterText";
-            // 
-            // label9
-            // 
-            label9.Anchor = AnchorStyles.Left;
-            label9.AutoSize = true;
-            label9.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label9.ForeColor = Color.FromArgb(64, 64, 64);
-            label9.Location = new Point(18, 177);
-            label9.Name = "label9";
-            label9.Size = new Size(32, 16);
-            label9.TabIndex = 1;
-            label9.Text = "Unit";
-            // 
-            // label10
-            // 
-            label10.Anchor = AnchorStyles.Left;
-            label10.AutoSize = true;
-            label10.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label10.ForeColor = Color.FromArgb(64, 64, 64);
-            label10.Location = new Point(18, 208);
-            label10.Name = "label10";
-            label10.Size = new Size(59, 16);
-            label10.TabIndex = 1;
-            label10.Text = "UnitText";
-            // 
-            // label11
-            // 
-            label11.Anchor = AnchorStyles.Left;
-            label11.AutoSize = true;
-            label11.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label11.ForeColor = Color.FromArgb(64, 64, 64);
-            label11.Location = new Point(18, 239);
-            label11.Name = "label11";
-            label11.Size = new Size(56, 16);
-            label11.TabIndex = 1;
-            label11.Text = "IsActive";
-            // 
-            // label12
-            // 
-            label12.Anchor = AnchorStyles.Left;
-            label12.AutoSize = true;
-            label12.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label12.ForeColor = Color.FromArgb(64, 64, 64);
-            label12.Location = new Point(18, 270);
-            label12.Name = "label12";
-            label12.Size = new Size(119, 16);
-            label12.TabIndex = 1;
-            label12.Text = "ChannelMinValue";
-            // 
-            // label13
-            // 
-            label13.Anchor = AnchorStyles.Left;
-            label13.AutoSize = true;
-            label13.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label13.ForeColor = Color.FromArgb(64, 64, 64);
-            label13.Location = new Point(18, 301);
-            label13.Name = "label13";
-            label13.Size = new Size(123, 16);
-            label13.TabIndex = 1;
-            label13.Text = "ChannelMaxValue";
-            // 
-            // label14
-            // 
-            label14.Anchor = AnchorStyles.Left;
-            label14.AutoSize = true;
-            label14.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label14.ForeColor = Color.FromArgb(64, 64, 64);
-            label14.Location = new Point(18, 332);
-            label14.Name = "label14";
-            label14.Size = new Size(110, 16);
-            label14.TabIndex = 1;
-            label14.Text = "ChannelNumber";
-            // 
-            // label15
-            // 
-            label15.Anchor = AnchorStyles.Left;
-            label15.AutoSize = true;
-            label15.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label15.ForeColor = Color.FromArgb(64, 64, 64);
-            label15.Location = new Point(18, 363);
-            label15.Name = "label15";
-            label15.Size = new Size(139, 16);
-            label15.TabIndex = 1;
-            label15.Text = "CalibrationFormulaA";
-            // 
-            // label16
-            // 
-            label16.Anchor = AnchorStyles.Left;
-            label16.AutoSize = true;
-            label16.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label16.ForeColor = Color.FromArgb(64, 64, 64);
-            label16.Location = new Point(18, 394);
-            label16.Name = "label16";
-            label16.Size = new Size(139, 16);
-            label16.TabIndex = 1;
-            label16.Text = "CalibrationFormulaB";
-            // 
-            // label17
-            // 
-            label17.Anchor = AnchorStyles.Left;
-            label17.AutoSize = true;
-            label17.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label17.ForeColor = Color.FromArgb(64, 64, 64);
-            label17.Location = new Point(18, 425);
-            label17.Name = "label17";
-            label17.Size = new Size(95, 16);
-            label17.TabIndex = 1;
-            label17.Text = "SerialNumber";
-            // 
-            // textBox3
-            // 
-            textBox3.Anchor = AnchorStyles.Left;
-            textBox3.Location = new Point(234, 81);
-            textBox3.Name = "textBox3";
-            textBox3.Size = new Size(288, 23);
-            textBox3.TabIndex = 2;
-            // 
-            // textBox1
-            // 
-            textBox1.Anchor = AnchorStyles.Left;
-            textBox1.Location = new Point(234, 19);
-            textBox1.Name = "textBox1";
-            textBox1.Size = new Size(288, 23);
-            textBox1.TabIndex = 2;
-            // 
-            // textBox2
-            // 
-            textBox2.Anchor = AnchorStyles.Left;
-            textBox2.Location = new Point(234, 50);
-            textBox2.Name = "textBox2";
-            textBox2.Size = new Size(288, 23);
-            textBox2.TabIndex = 2;
-            // 
-            // textBox5
-            // 
-            textBox5.Anchor = AnchorStyles.Left;
-            textBox5.Location = new Point(234, 112);
-            textBox5.Name = "textBox5";
-            textBox5.Size = new Size(288, 23);
-            textBox5.TabIndex = 2;
-            // 
-            // textBox6
-            // 
-            textBox6.Anchor = AnchorStyles.Left;
-            textBox6.Location = new Point(234, 143);
-            textBox6.Name = "textBox6";
-            textBox6.Size = new Size(288, 23);
-            textBox6.TabIndex = 2;
-            // 
-            // textBox7
-            // 
-            textBox7.Anchor = AnchorStyles.Left;
-            textBox7.Location = new Point(234, 174);
-            textBox7.Name = "textBox7";
-            textBox7.Size = new Size(288, 23);
-            textBox7.TabIndex = 2;
-            // 
-            // textBox8
-            // 
-            textBox8.Anchor = AnchorStyles.Left;
-            textBox8.Location = new Point(234, 205);
-            textBox8.Name = "textBox8";
-            textBox8.Size = new Size(288, 23);
-            textBox8.TabIndex = 2;
-            // 
-            // textBox9
-            // 
-            textBox9.Anchor = AnchorStyles.Left;
-            textBox9.Location = new Point(234, 236);
-            textBox9.Name = "textBox9";
-            textBox9.Size = new Size(288, 23);
-            textBox9.TabIndex = 2;
-            // 
-            // textBox10
-            // 
-            textBox10.Anchor = AnchorStyles.Left;
-            textBox10.Location = new Point(234, 267);
-            textBox10.Name = "textBox10";
-            textBox10.Size = new Size(288, 23);
-            textBox10.TabIndex = 2;
-            // 
-            // textBox11
-            // 
-            textBox11.Anchor = AnchorStyles.Left;
-            textBox11.Location = new Point(234, 298);
-            textBox11.Name = "textBox11";
-            textBox11.Size = new Size(288, 23);
-            textBox11.TabIndex = 2;
-            // 
-            // textBox12
-            // 
-            textBox12.Anchor = AnchorStyles.Left;
-            textBox12.Location = new Point(234, 329);
-            textBox12.Name = "textBox12";
-            textBox12.Size = new Size(288, 23);
-            textBox12.TabIndex = 2;
-            // 
-            // textBox13
-            // 
-            textBox13.Anchor = AnchorStyles.Left;
-            textBox13.Location = new Point(234, 360);
-            textBox13.Name = "textBox13";
-            textBox13.Size = new Size(288, 23);
-            textBox13.TabIndex = 2;
-            // 
-            // textBox14
-            // 
-            textBox14.Anchor = AnchorStyles.Left;
-            textBox14.Location = new Point(234, 391);
-            textBox14.Name = "textBox14";
-            textBox14.Size = new Size(288, 23);
-            textBox14.TabIndex = 2;
-            // 
-            // textBox15
-            // 
-            textBox15.Anchor = AnchorStyles.Left;
-            textBox15.Location = new Point(234, 422);
-            textBox15.Name = "textBox15";
-            textBox15.Size = new Size(288, 23);
-            textBox15.TabIndex = 2;
-            // 
-            // tableLayoutPanel2
-            // 
-            tableLayoutPanel2.BackColor = Color.White;
-            tableLayoutPanel2.ColumnCount = 2;
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
-            tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel2.Controls.Add(label18, 0, 0);
-            tableLayoutPanel2.Controls.Add(label19, 0, 1);
-            tableLayoutPanel2.Controls.Add(label20, 0, 2);
-            tableLayoutPanel2.Controls.Add(label21, 0, 3);
-            tableLayoutPanel2.Controls.Add(label22, 0, 4);
-            tableLayoutPanel2.Controls.Add(label23, 0, 5);
-            tableLayoutPanel2.Controls.Add(label24, 0, 6);
-            tableLayoutPanel2.Controls.Add(textBox4, 1, 2);
-            tableLayoutPanel2.Controls.Add(textBox16, 1, 0);
-            tableLayoutPanel2.Controls.Add(textBox17, 1, 1);
-            tableLayoutPanel2.Controls.Add(textBox18, 1, 3);
-            tableLayoutPanel2.Controls.Add(textBox19, 1, 4);
-            tableLayoutPanel2.Controls.Add(textBox20, 1, 5);
-            tableLayoutPanel2.Controls.Add(textBox21, 1, 6);
-            tableLayoutPanel2.Dock = DockStyle.Fill;
-            tableLayoutPanel2.Location = new Point(1, 1);
-            tableLayoutPanel2.Margin = new Padding(1);
-            tableLayoutPanel2.Name = "tableLayoutPanel2";
-            tableLayoutPanel2.Padding = new Padding(15);
-            tableLayoutPanel2.RowCount = 14;
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
-            tableLayoutPanel2.Size = new Size(540, 461);
-            tableLayoutPanel2.TabIndex = 3;
-            // 
-            // label18
-            // 
-            label18.Anchor = AnchorStyles.Left;
-            label18.AutoSize = true;
-            label18.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label18.ForeColor = Color.FromArgb(64, 64, 64);
-            label18.Location = new Point(18, 22);
-            label18.Name = "label18";
-            label18.Size = new Size(32, 16);
-            label18.TabIndex = 1;
-            label18.Text = "Unit";
-            // 
-            // label19
-            // 
-            label19.Anchor = AnchorStyles.Left;
-            label19.AutoSize = true;
-            label19.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label19.ForeColor = Color.FromArgb(64, 64, 64);
-            label19.Location = new Point(18, 53);
-            label19.Name = "label19";
-            label19.Size = new Size(56, 16);
-            label19.TabIndex = 1;
-            label19.Text = "IsActive";
-            // 
-            // label20
-            // 
-            label20.Anchor = AnchorStyles.Left;
-            label20.AutoSize = true;
-            label20.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label20.ForeColor = Color.FromArgb(64, 64, 64);
-            label20.Location = new Point(18, 84);
-            label20.Name = "label20";
-            label20.Size = new Size(119, 16);
-            label20.TabIndex = 1;
-            label20.Text = "ChannelMinValue";
-            // 
-            // label21
-            // 
-            label21.Anchor = AnchorStyles.Left;
-            label21.AutoSize = true;
-            label21.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label21.ForeColor = Color.FromArgb(64, 64, 64);
-            label21.Location = new Point(18, 115);
-            label21.Name = "label21";
-            label21.Size = new Size(123, 16);
-            label21.TabIndex = 1;
-            label21.Text = "ChannelMaxValue";
-            // 
-            // label22
-            // 
-            label22.Anchor = AnchorStyles.Left;
-            label22.AutoSize = true;
-            label22.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label22.ForeColor = Color.FromArgb(64, 64, 64);
-            label22.Location = new Point(18, 146);
-            label22.Name = "label22";
-            label22.Size = new Size(110, 16);
-            label22.TabIndex = 1;
-            label22.Text = "ChannelNumber";
-            // 
-            // label23
-            // 
-            label23.Anchor = AnchorStyles.Left;
-            label23.AutoSize = true;
-            label23.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label23.ForeColor = Color.FromArgb(64, 64, 64);
-            label23.Location = new Point(18, 177);
-            label23.Name = "label23";
-            label23.Size = new Size(139, 16);
-            label23.TabIndex = 1;
-            label23.Text = "CalibrationFormulaA";
-            // 
-            // label24
-            // 
-            label24.Anchor = AnchorStyles.Left;
-            label24.AutoSize = true;
-            label24.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label24.ForeColor = Color.FromArgb(64, 64, 64);
-            label24.Location = new Point(18, 208);
-            label24.Name = "label24";
-            label24.Size = new Size(139, 16);
-            label24.TabIndex = 1;
-            label24.Text = "CalibrationFormulaB";
-            // 
-            // textBox4
-            // 
-            textBox4.Anchor = AnchorStyles.Left;
-            textBox4.Location = new Point(234, 81);
-            textBox4.Name = "textBox4";
-            textBox4.Size = new Size(288, 23);
-            textBox4.TabIndex = 2;
-            // 
-            // textBox16
-            // 
-            textBox16.Anchor = AnchorStyles.Left;
-            textBox16.Location = new Point(234, 19);
-            textBox16.Name = "textBox16";
-            textBox16.Size = new Size(288, 23);
-            textBox16.TabIndex = 2;
-            // 
-            // textBox17
-            // 
-            textBox17.Anchor = AnchorStyles.Left;
-            textBox17.Location = new Point(234, 50);
-            textBox17.Name = "textBox17";
-            textBox17.Size = new Size(288, 23);
-            textBox17.TabIndex = 2;
-            // 
-            // textBox18
-            // 
-            textBox18.Anchor = AnchorStyles.Left;
-            textBox18.Location = new Point(234, 112);
-            textBox18.Name = "textBox18";
-            textBox18.Size = new Size(288, 23);
-            textBox18.TabIndex = 2;
-            // 
-            // textBox19
-            // 
-            textBox19.Anchor = AnchorStyles.Left;
-            textBox19.Location = new Point(234, 143);
-            textBox19.Name = "textBox19";
-            textBox19.Size = new Size(288, 23);
-            textBox19.TabIndex = 2;
-            // 
-            // textBox20
-            // 
-            textBox20.Anchor = AnchorStyles.Left;
-            textBox20.Location = new Point(234, 174);
-            textBox20.Name = "textBox20";
-            textBox20.Size = new Size(288, 23);
-            textBox20.TabIndex = 2;
-            // 
-            // textBox21
-            // 
-            textBox21.Anchor = AnchorStyles.Left;
-            textBox21.Location = new Point(234, 205);
-            textBox21.Name = "textBox21";
-            textBox21.Size = new Size(288, 23);
-            textBox21.TabIndex = 2;
-            // 
-            // tableLayoutPanel3
-            // 
-            tableLayoutPanel3.ColumnCount = 2;
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 264F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel3.Controls.Add(label32, 0, 0);
-            tableLayoutPanel3.Controls.Add(button1, 1, 0);
-            tableLayoutPanel3.Dock = DockStyle.Fill;
-            tableLayoutPanel3.Location = new Point(547, 0);
-            tableLayoutPanel3.Margin = new Padding(0);
-            tableLayoutPanel3.Name = "tableLayoutPanel3";
-            tableLayoutPanel3.RowCount = 1;
-            tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            tableLayoutPanel3.Size = new Size(547, 40);
-            tableLayoutPanel3.TabIndex = 7;
-            // 
-            // label32
-            // 
-            label32.AutoSize = true;
-            label32.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label32.ForeColor = Color.FromArgb(64, 64, 64);
-            label32.Location = new Point(3, 0);
-            label32.Name = "label32";
-            label32.Size = new Size(242, 22);
-            label32.TabIndex = 0;
-            label32.Text = "Kanal Bilgilerini Güncelle";
-            // 
-            // button1
-            // 
-            button1.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            button1.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button1.Location = new Point(452, 3);
-            button1.Name = "button1";
-            button1.Size = new Size(92, 32);
-            button1.TabIndex = 2;
-            button1.Text = "Kaydet";
-            button1.UseVisualStyleBackColor = true;
+            // BrandLabel
+            // 
+            BrandLabel.Anchor = AnchorStyles.Left;
+            BrandLabel.AutoSize = true;
+            BrandLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            BrandLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            BrandLabel.Location = new Point(18, 22);
+            BrandLabel.Name = "BrandLabel";
+            BrandLabel.Size = new Size(45, 16);
+            BrandLabel.TabIndex = 1;
+            BrandLabel.Text = "Brand";
+            // 
+            // BrandModelLabel
+            // 
+            BrandModelLabel.Anchor = AnchorStyles.Left;
+            BrandModelLabel.AutoSize = true;
+            BrandModelLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            BrandModelLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            BrandModelLabel.Location = new Point(18, 53);
+            BrandModelLabel.Name = "BrandModelLabel";
+            BrandModelLabel.Size = new Size(84, 16);
+            BrandModelLabel.TabIndex = 1;
+            BrandModelLabel.Text = "BrandModel";
+            // 
+            // FullNameLabel
+            // 
+            FullNameLabel.Anchor = AnchorStyles.Left;
+            FullNameLabel.AutoSize = true;
+            FullNameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            FullNameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            FullNameLabel.Location = new Point(18, 84);
+            FullNameLabel.Name = "FullNameLabel";
+            FullNameLabel.Size = new Size(68, 16);
+            FullNameLabel.TabIndex = 1;
+            FullNameLabel.Text = "FullName";
+            // 
+            // ChannelComboBox
+            // 
+            ChannelComboBox.Anchor = AnchorStyles.Left;
+            ChannelComboBox.FormattingEnabled = true;
+            ChannelComboBox.Location = new Point(263, 8);
+            ChannelComboBox.Name = "ChannelComboBox";
+            ChannelComboBox.Size = new Size(121, 23);
+            ChannelComboBox.TabIndex = 3;
+            // 
+            // ChannelLabel
+            // 
+            ChannelLabel.Anchor = AnchorStyles.Left;
+            ChannelLabel.AutoSize = true;
+            ChannelLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelLabel.Location = new Point(203, 12);
+            ChannelLabel.Name = "ChannelLabel";
+            ChannelLabel.Size = new Size(48, 16);
+            ChannelLabel.TabIndex = 1;
+            ChannelLabel.Text = "Kanal:";
+            // 
+            // ParameterLabel
+            // 
+            ParameterLabel.Anchor = AnchorStyles.Left;
+            ParameterLabel.AutoSize = true;
+            ParameterLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ParameterLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ParameterLabel.Location = new Point(18, 115);
+            ParameterLabel.Name = "ParameterLabel";
+            ParameterLabel.Size = new Size(74, 16);
+            ParameterLabel.TabIndex = 1;
+            ParameterLabel.Text = "Parameter";
+            // 
+            // ParameterTextLabel
+            // 
+            ParameterTextLabel.Anchor = AnchorStyles.Left;
+            ParameterTextLabel.AutoSize = true;
+            ParameterTextLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ParameterTextLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ParameterTextLabel.Location = new Point(18, 146);
+            ParameterTextLabel.Name = "ParameterTextLabel";
+            ParameterTextLabel.Size = new Size(101, 16);
+            ParameterTextLabel.TabIndex = 1;
+            ParameterTextLabel.Text = "ParameterText";
+            // 
+            // UnitLabel
+            // 
+            UnitLabel.Anchor = AnchorStyles.Left;
+            UnitLabel.AutoSize = true;
+            UnitLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            UnitLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            UnitLabel.Location = new Point(18, 177);
+            UnitLabel.Name = "UnitLabel";
+            UnitLabel.Size = new Size(32, 16);
+            UnitLabel.TabIndex = 1;
+            UnitLabel.Text = "Unit";
+            // 
+            // UnitTextLabel
+            // 
+            UnitTextLabel.Anchor = AnchorStyles.Left;
+            UnitTextLabel.AutoSize = true;
+            UnitTextLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            UnitTextLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            UnitTextLabel.Location = new Point(18, 208);
+            UnitTextLabel.Name = "UnitTextLabel";
+            UnitTextLabel.Size = new Size(59, 16);
+            UnitTextLabel.TabIndex = 1;
+            UnitTextLabel.Text = "UnitText";
+            // 
+            // IsActiveLabel
+            // 
+            IsActiveLabel.Anchor = AnchorStyles.Left;
+            IsActiveLabel.AutoSize = true;
+            IsActiveLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            IsActiveLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            IsActiveLabel.Location = new Point(18, 239);
+            IsActiveLabel.Name = "IsActiveLabel";
+            IsActiveLabel.Size = new Size(56, 16);
+            IsActiveLabel.TabIndex = 1;
+            IsActiveLabel.Text = "IsActive";
+            // 
+            // ChannelMinValueLabel
+            // 
+            ChannelMinValueLabel.Anchor = AnchorStyles.Left;
+            ChannelMinValueLabel.AutoSize = true;
+            ChannelMinValueLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelMinValueLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelMinValueLabel.Location = new Point(18, 270);
+            ChannelMinValueLabel.Name = "ChannelMinValueLabel";
+            ChannelMinValueLabel.Size = new Size(119, 16);
+            ChannelMinValueLabel.TabIndex = 1;
+            ChannelMinValueLabel.Text = "ChannelMinValue";
+            // 
+            // ChannelMaxValueLabel
+            // 
+            ChannelMaxValueLabel.Anchor = AnchorStyles.Left;
+            ChannelMaxValueLabel.AutoSize = true;
+            ChannelMaxValueLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelMaxValueLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelMaxValueLabel.Location = new Point(18, 301);
+            ChannelMaxValueLabel.Name = "ChannelMaxValueLabel";
+            ChannelMaxValueLabel.Size = new Size(123, 16);
+            ChannelMaxValueLabel.TabIndex = 1;
+            ChannelMaxValueLabel.Text = "ChannelMaxValue";
+            // 
+            // ChannelNumberLabel
+            // 
+            ChannelNumberLabel.Anchor = AnchorStyles.Left;
+            ChannelNumberLabel.AutoSize = true;
+            ChannelNumberLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelNumberLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelNumberLabel.Location = new Point(18, 332);
+            ChannelNumberLabel.Name = "ChannelNumberLabel";
+            ChannelNumberLabel.Size = new Size(110, 16);
+            ChannelNumberLabel.TabIndex = 1;
+            ChannelNumberLabel.Text = "ChannelNumber";
+            // 
+            // CalibrationFormulaALabel
+            // 
+            CalibrationFormulaALabel.Anchor = AnchorStyles.Left;
+            CalibrationFormulaALabel.AutoSize = true;
+            CalibrationFormulaALabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CalibrationFormulaALabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CalibrationFormulaALabel.Location = new Point(18, 363);
+            CalibrationFormulaALabel.Name = "CalibrationFormulaALabel";
+            CalibrationFormulaALabel.Size = new Size(139, 16);
+            CalibrationFormulaALabel.TabIndex = 1;
+            CalibrationFormulaALabel.Text = "CalibrationFormulaA";
+            // 
+            // CalibrationFormulaBLabel
+            // 
+            CalibrationFormulaBLabel.Anchor = AnchorStyles.Left;
+            CalibrationFormulaBLabel.AutoSize = true;
+            CalibrationFormulaBLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CalibrationFormulaBLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CalibrationFormulaBLabel.Location = new Point(18, 394);
+            CalibrationFormulaBLabel.Name = "CalibrationFormulaBLabel";
+            CalibrationFormulaBLabel.Size = new Size(139, 16);
+            CalibrationFormulaBLabel.TabIndex = 1;
+            CalibrationFormulaBLabel.Text = "CalibrationFormulaB";
+            // 
+            // SerialNumberLabel
+            // 
+            SerialNumberLabel.Anchor = AnchorStyles.Left;
+            SerialNumberLabel.AutoSize = true;
+            SerialNumberLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            SerialNumberLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            SerialNumberLabel.Location = new Point(18, 425);
+            SerialNumberLabel.Name = "SerialNumberLabel";
+            SerialNumberLabel.Size = new Size(95, 16);
+            SerialNumberLabel.TabIndex = 1;
+            SerialNumberLabel.Text = "SerialNumber";
+            // 
+            // FullNameTextBox
+            // 
+            FullNameTextBox.Anchor = AnchorStyles.Left;
+            FullNameTextBox.Location = new Point(234, 81);
+            FullNameTextBox.Name = "FullNameTextBox";
+            FullNameTextBox.Size = new Size(288, 23);
+            FullNameTextBox.TabIndex = 2;
+            // 
+            // BrandTextBox
+            // 
+            BrandTextBox.Anchor = AnchorStyles.Left;
+            BrandTextBox.Location = new Point(234, 19);
+            BrandTextBox.Name = "BrandTextBox";
+            BrandTextBox.Size = new Size(288, 23);
+            BrandTextBox.TabIndex = 2;
+            // 
+            // BrandModelTextBox
+            // 
+            BrandModelTextBox.Anchor = AnchorStyles.Left;
+            BrandModelTextBox.Location = new Point(234, 50);
+            BrandModelTextBox.Name = "BrandModelTextBox";
+            BrandModelTextBox.Size = new Size(288, 23);
+            BrandModelTextBox.TabIndex = 2;
+            // 
+            // ParameterTextBox
+            // 
+            ParameterTextBox.Anchor = AnchorStyles.Left;
+            ParameterTextBox.Location = new Point(234, 112);
+            ParameterTextBox.Name = "ParameterTextBox";
+            ParameterTextBox.Size = new Size(288, 23);
+            ParameterTextBox.TabIndex = 2;
+            // 
+            // ParameterTextTextBox
+            // 
+            ParameterTextTextBox.Anchor = AnchorStyles.Left;
+            ParameterTextTextBox.Location = new Point(234, 143);
+            ParameterTextTextBox.Name = "ParameterTextTextBox";
+            ParameterTextTextBox.Size = new Size(288, 23);
+            ParameterTextTextBox.TabIndex = 2;
+            // 
+            // UnitTextBox
+            // 
+            UnitTextBox.Anchor = AnchorStyles.Left;
+            UnitTextBox.Location = new Point(234, 174);
+            UnitTextBox.Name = "UnitTextBox";
+            UnitTextBox.Size = new Size(288, 23);
+            UnitTextBox.TabIndex = 2;
+            // 
+            // UnitTextTextBox
+            // 
+            UnitTextTextBox.Anchor = AnchorStyles.Left;
+            UnitTextTextBox.Location = new Point(234, 205);
+            UnitTextTextBox.Name = "UnitTextTextBox";
+            UnitTextTextBox.Size = new Size(288, 23);
+            UnitTextTextBox.TabIndex = 2;
+            // 
+            // IsActiveTextBox
+            // 
+            IsActiveTextBox.Anchor = AnchorStyles.Left;
+            IsActiveTextBox.Location = new Point(234, 236);
+            IsActiveTextBox.Name = "IsActiveTextBox";
+            IsActiveTextBox.Size = new Size(288, 23);
+            IsActiveTextBox.TabIndex = 2;
+            // 
+            // ChannelMinValueTextBox
+            // 
+            ChannelMinValueTextBox.Anchor = AnchorStyles.Left;
+            ChannelMinValueTextBox.Location = new Point(234, 267);
+            ChannelMinValueTextBox.Name = "ChannelMinValueTextBox";
+            ChannelMinValueTextBox.Size = new Size(288, 23);
+            ChannelMinValueTextBox.TabIndex = 2;
+            // 
+            // ChannelMaxValueTextBox
+            // 
+            ChannelMaxValueTextBox.Anchor = AnchorStyles.Left;
+            ChannelMaxValueTextBox.Location = new Point(234, 298);
+            ChannelMaxValueTextBox.Name = "ChannelMaxValueTextBox";
+            ChannelMaxValueTextBox.Size = new Size(288, 23);
+            ChannelMaxValueTextBox.TabIndex = 2;
+            // 
+            // ChannelNumberTextBox
+            // 
+            ChannelNumberTextBox.Anchor = AnchorStyles.Left;
+            ChannelNumberTextBox.Location = new Point(234, 329);
+            ChannelNumberTextBox.Name = "ChannelNumberTextBox";
+            ChannelNumberTextBox.Size = new Size(288, 23);
+            ChannelNumberTextBox.TabIndex = 2;
+            // 
+            // CalibrationFormulaATextBox
+            // 
+            CalibrationFormulaATextBox.Anchor = AnchorStyles.Left;
+            CalibrationFormulaATextBox.Location = new Point(234, 360);
+            CalibrationFormulaATextBox.Name = "CalibrationFormulaATextBox";
+            CalibrationFormulaATextBox.Size = new Size(288, 23);
+            CalibrationFormulaATextBox.TabIndex = 2;
+            // 
+            // CalibrationFormulaBTextBox
+            // 
+            CalibrationFormulaBTextBox.Anchor = AnchorStyles.Left;
+            CalibrationFormulaBTextBox.Location = new Point(234, 391);
+            CalibrationFormulaBTextBox.Name = "CalibrationFormulaBTextBox";
+            CalibrationFormulaBTextBox.Size = new Size(288, 23);
+            CalibrationFormulaBTextBox.TabIndex = 2;
+            // 
+            // SerialNumberTextBox
+            // 
+            SerialNumberTextBox.Anchor = AnchorStyles.Left;
+            SerialNumberTextBox.Location = new Point(234, 422);
+            SerialNumberTextBox.Name = "SerialNumberTextBox";
+            SerialNumberTextBox.Size = new Size(288, 23);
+            SerialNumberTextBox.TabIndex = 2;
+            // 
+            // UpdateChannelContentTableLayoutPanel
+            // 
+            UpdateChannelContentTableLayoutPanel.BackColor = Color.White;
+            UpdateChannelContentTableLayoutPanel.ColumnCount = 2;
+            UpdateChannelContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
+            UpdateChannelContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
+            UpdateChannelContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+            UpdateChannelContentTableLayoutPanel.Controls.Add(UnitUpdateLabel, 0, 0);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(IsActiveUpdateLabel, 0, 1);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelMinValueUpdateLabel, 0, 2);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelMaxValueUpdateLabel, 0, 3);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelNumberUpdateLabel, 0, 4);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(CalibrationFormulaAUpdateLabel, 0, 5);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(CalibrationFormulaBUpdateLabel, 0, 6);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelMinValueUpdateTextBox, 1, 2);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(UnitUpdateTextBox, 1, 0);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(IsActiveUpdateTextBox, 1, 1);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelMaxValueUpdateTextBox, 1, 3);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(ChannelNumberUpdateTextBox, 1, 4);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(CalibrationFormulaAUpdateTextBox, 1, 5);
+            UpdateChannelContentTableLayoutPanel.Controls.Add(CalibrationFormulaBUpdateTextBox, 1, 6);
+            UpdateChannelContentTableLayoutPanel.Dock = DockStyle.Fill;
+            UpdateChannelContentTableLayoutPanel.Location = new Point(1, 1);
+            UpdateChannelContentTableLayoutPanel.Margin = new Padding(1);
+            UpdateChannelContentTableLayoutPanel.Name = "UpdateChannelContentTableLayoutPanel";
+            UpdateChannelContentTableLayoutPanel.Padding = new Padding(15);
+            UpdateChannelContentTableLayoutPanel.RowCount = 14;
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 31F));
+            UpdateChannelContentTableLayoutPanel.Size = new Size(540, 461);
+            UpdateChannelContentTableLayoutPanel.TabIndex = 3;
+            // 
+            // UnitUpdateLabel
+            // 
+            UnitUpdateLabel.Anchor = AnchorStyles.Left;
+            UnitUpdateLabel.AutoSize = true;
+            UnitUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            UnitUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            UnitUpdateLabel.Location = new Point(18, 22);
+            UnitUpdateLabel.Name = "UnitUpdateLabel";
+            UnitUpdateLabel.Size = new Size(32, 16);
+            UnitUpdateLabel.TabIndex = 1;
+            UnitUpdateLabel.Text = "Unit";
+            // 
+            // IsActiveUpdateLabel
+            // 
+            IsActiveUpdateLabel.Anchor = AnchorStyles.Left;
+            IsActiveUpdateLabel.AutoSize = true;
+            IsActiveUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            IsActiveUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            IsActiveUpdateLabel.Location = new Point(18, 53);
+            IsActiveUpdateLabel.Name = "IsActiveUpdateLabel";
+            IsActiveUpdateLabel.Size = new Size(56, 16);
+            IsActiveUpdateLabel.TabIndex = 1;
+            IsActiveUpdateLabel.Text = "IsActive";
+            // 
+            // ChannelMinValueUpdateLabel
+            // 
+            ChannelMinValueUpdateLabel.Anchor = AnchorStyles.Left;
+            ChannelMinValueUpdateLabel.AutoSize = true;
+            ChannelMinValueUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelMinValueUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelMinValueUpdateLabel.Location = new Point(18, 84);
+            ChannelMinValueUpdateLabel.Name = "ChannelMinValueUpdateLabel";
+            ChannelMinValueUpdateLabel.Size = new Size(119, 16);
+            ChannelMinValueUpdateLabel.TabIndex = 1;
+            ChannelMinValueUpdateLabel.Text = "ChannelMinValue";
+            // 
+            // ChannelMaxValueUpdateLabel
+            // 
+            ChannelMaxValueUpdateLabel.Anchor = AnchorStyles.Left;
+            ChannelMaxValueUpdateLabel.AutoSize = true;
+            ChannelMaxValueUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelMaxValueUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelMaxValueUpdateLabel.Location = new Point(18, 115);
+            ChannelMaxValueUpdateLabel.Name = "ChannelMaxValueUpdateLabel";
+            ChannelMaxValueUpdateLabel.Size = new Size(123, 16);
+            ChannelMaxValueUpdateLabel.TabIndex = 1;
+            ChannelMaxValueUpdateLabel.Text = "ChannelMaxValue";
+            // 
+            // ChannelNumberUpdateLabel
+            // 
+            ChannelNumberUpdateLabel.Anchor = AnchorStyles.Left;
+            ChannelNumberUpdateLabel.AutoSize = true;
+            ChannelNumberUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ChannelNumberUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ChannelNumberUpdateLabel.Location = new Point(18, 146);
+            ChannelNumberUpdateLabel.Name = "ChannelNumberUpdateLabel";
+            ChannelNumberUpdateLabel.Size = new Size(110, 16);
+            ChannelNumberUpdateLabel.TabIndex = 1;
+            ChannelNumberUpdateLabel.Text = "ChannelNumber";
+            // 
+            // CalibrationFormulaAUpdateLabel
+            // 
+            CalibrationFormulaAUpdateLabel.Anchor = AnchorStyles.Left;
+            CalibrationFormulaAUpdateLabel.AutoSize = true;
+            CalibrationFormulaAUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CalibrationFormulaAUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CalibrationFormulaAUpdateLabel.Location = new Point(18, 177);
+            CalibrationFormulaAUpdateLabel.Name = "CalibrationFormulaAUpdateLabel";
+            CalibrationFormulaAUpdateLabel.Size = new Size(139, 16);
+            CalibrationFormulaAUpdateLabel.TabIndex = 1;
+            CalibrationFormulaAUpdateLabel.Text = "CalibrationFormulaA";
+            // 
+            // CalibrationFormulaBUpdateLabel
+            // 
+            CalibrationFormulaBUpdateLabel.Anchor = AnchorStyles.Left;
+            CalibrationFormulaBUpdateLabel.AutoSize = true;
+            CalibrationFormulaBUpdateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CalibrationFormulaBUpdateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CalibrationFormulaBUpdateLabel.Location = new Point(18, 208);
+            CalibrationFormulaBUpdateLabel.Name = "CalibrationFormulaBUpdateLabel";
+            CalibrationFormulaBUpdateLabel.Size = new Size(139, 16);
+            CalibrationFormulaBUpdateLabel.TabIndex = 1;
+            CalibrationFormulaBUpdateLabel.Text = "CalibrationFormulaB";
+            // 
+            // ChannelMinValueUpdateTextBox
+            // 
+            ChannelMinValueUpdateTextBox.Anchor = AnchorStyles.Left;
+            ChannelMinValueUpdateTextBox.Location = new Point(234, 81);
+            ChannelMinValueUpdateTextBox.Name = "ChannelMinValueUpdateTextBox";
+            ChannelMinValueUpdateTextBox.Size = new Size(288, 23);
+            ChannelMinValueUpdateTextBox.TabIndex = 2;
+            // 
+            // UnitUpdateTextBox
+            // 
+            UnitUpdateTextBox.Anchor = AnchorStyles.Left;
+            UnitUpdateTextBox.Location = new Point(234, 19);
+            UnitUpdateTextBox.Name = "UnitUpdateTextBox";
+            UnitUpdateTextBox.Size = new Size(288, 23);
+            UnitUpdateTextBox.TabIndex = 2;
+            // 
+            // IsActiveUpdateTextBox
+            // 
+            IsActiveUpdateTextBox.Anchor = AnchorStyles.Left;
+            IsActiveUpdateTextBox.Location = new Point(234, 50);
+            IsActiveUpdateTextBox.Name = "IsActiveUpdateTextBox";
+            IsActiveUpdateTextBox.Size = new Size(288, 23);
+            IsActiveUpdateTextBox.TabIndex = 2;
+            // 
+            // ChannelMaxValueUpdateTextBox
+            // 
+            ChannelMaxValueUpdateTextBox.Anchor = AnchorStyles.Left;
+            ChannelMaxValueUpdateTextBox.Location = new Point(234, 112);
+            ChannelMaxValueUpdateTextBox.Name = "ChannelMaxValueUpdateTextBox";
+            ChannelMaxValueUpdateTextBox.Size = new Size(288, 23);
+            ChannelMaxValueUpdateTextBox.TabIndex = 2;
+            // 
+            // ChannelNumberUpdateTextBox
+            // 
+            ChannelNumberUpdateTextBox.Anchor = AnchorStyles.Left;
+            ChannelNumberUpdateTextBox.Location = new Point(234, 143);
+            ChannelNumberUpdateTextBox.Name = "ChannelNumberUpdateTextBox";
+            ChannelNumberUpdateTextBox.Size = new Size(288, 23);
+            ChannelNumberUpdateTextBox.TabIndex = 2;
+            // 
+            // CalibrationFormulaAUpdateTextBox
+            // 
+            CalibrationFormulaAUpdateTextBox.Anchor = AnchorStyles.Left;
+            CalibrationFormulaAUpdateTextBox.Location = new Point(234, 174);
+            CalibrationFormulaAUpdateTextBox.Name = "CalibrationFormulaAUpdateTextBox";
+            CalibrationFormulaAUpdateTextBox.Size = new Size(288, 23);
+            CalibrationFormulaAUpdateTextBox.TabIndex = 2;
+            // 
+            // CalibrationFormulaBUpdateTextBox
+            // 
+            CalibrationFormulaBUpdateTextBox.Anchor = AnchorStyles.Left;
+            CalibrationFormulaBUpdateTextBox.Location = new Point(234, 205);
+            CalibrationFormulaBUpdateTextBox.Name = "CalibrationFormulaBUpdateTextBox";
+            CalibrationFormulaBUpdateTextBox.Size = new Size(288, 23);
+            CalibrationFormulaBUpdateTextBox.TabIndex = 2;
+            // 
+            // UpdateChannelHeaderTableLayoutPanel
+            // 
+            UpdateChannelHeaderTableLayoutPanel.ColumnCount = 2;
+            UpdateChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 264F));
+            UpdateChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            UpdateChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+            UpdateChannelHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
+            UpdateChannelHeaderTableLayoutPanel.Controls.Add(UpdateChannelTitleLabel, 0, 0);
+            UpdateChannelHeaderTableLayoutPanel.Controls.Add(SaveChannelButton, 1, 0);
+            UpdateChannelHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            UpdateChannelHeaderTableLayoutPanel.Location = new Point(547, 0);
+            UpdateChannelHeaderTableLayoutPanel.Margin = new Padding(0);
+            UpdateChannelHeaderTableLayoutPanel.Name = "UpdateChannelHeaderTableLayoutPanel";
+            UpdateChannelHeaderTableLayoutPanel.RowCount = 1;
+            UpdateChannelHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            UpdateChannelHeaderTableLayoutPanel.Size = new Size(547, 40);
+            UpdateChannelHeaderTableLayoutPanel.TabIndex = 7;
+            // 
+            // UpdateChannelTitleLabel
+            // 
+            UpdateChannelTitleLabel.AutoSize = true;
+            UpdateChannelTitleLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            UpdateChannelTitleLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            UpdateChannelTitleLabel.Location = new Point(3, 0);
+            UpdateChannelTitleLabel.Name = "UpdateChannelTitleLabel";
+            UpdateChannelTitleLabel.Size = new Size(242, 22);
+            UpdateChannelTitleLabel.TabIndex = 0;
+            UpdateChannelTitleLabel.Text = "Kanal Bilgilerini Güncelle";
+            // 
+            // SaveChannelButton
+            // 
+            SaveChannelButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveChannelButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveChannelButton.Location = new Point(452, 3);
+            SaveChannelButton.Name = "SaveChannelButton";
+            SaveChannelButton.Size = new Size(92, 32);
+            SaveChannelButton.TabIndex = 2;
+            SaveChannelButton.Text = "Kaydet";
+            SaveChannelButton.UseVisualStyleBackColor = true;
             // 
             // ChannelSettingsPage
             // 
@@ -774,75 +774,75 @@
             Name = "ChannelSettingsPage";
             Padding = new Padding(0, 15, 0, 15);
             Size = new Size(1094, 533);
-            tableLayoutPanel1.ResumeLayout(false);
+            UpdateChannelBgTableLayoutPanel.ResumeLayout(false);
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            FetchChannelHeaderTableLayoutPanel.ResumeLayout(false);
+            FetchChannelHeaderTableLayoutPanel.PerformLayout();
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.PerformLayout();
-            tableLayoutPanel2.ResumeLayout(false);
-            tableLayoutPanel2.PerformLayout();
-            tableLayoutPanel3.ResumeLayout(false);
-            tableLayoutPanel3.PerformLayout();
+            UpdateChannelContentTableLayoutPanel.ResumeLayout(false);
+            UpdateChannelContentTableLayoutPanel.PerformLayout();
+            UpdateChannelHeaderTableLayoutPanel.ResumeLayout(false);
+            UpdateChannelHeaderTableLayoutPanel.PerformLayout();
             ResumeLayout(false);
         }
 
         #endregion
-        private TableLayoutPanel tableLayoutPanel1;
+        private TableLayoutPanel UpdateChannelBgTableLayoutPanel;
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
-        private TableLayoutPanel tableLayoutPanel4;
-        private Label label1;
-        private Button FetchButton;
+        private TableLayoutPanel FetchChannelHeaderTableLayoutPanel;
+        private Label FetchChannelTitleLabel;
+        private Button FetchChannelButton;
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
         private TableLayoutPanel StationInfoContentTableLayoutPanel;
-        private Label label4;
-        private Label label5;
-        private Label label6;
-        private ComboBox comboBox1;
-        private Label label2;
-        private Label label3;
-        private Label label7;
-        private Label label9;
-        private Label label10;
-        private Label label11;
-        private Label label12;
-        private Label label13;
-        private Label label14;
-        private Label label15;
-        private Label label16;
-        private Label label17;
-        private TextBox textBox3;
-        private TextBox textBox1;
-        private TextBox textBox2;
-        private TextBox textBox5;
-        private TextBox textBox6;
-        private TextBox textBox7;
-        private TextBox textBox8;
-        private TextBox textBox9;
-        private TextBox textBox10;
-        private TextBox textBox11;
-        private TextBox textBox12;
-        private TextBox textBox13;
-        private TextBox textBox14;
-        private TextBox textBox15;
-        private TableLayoutPanel tableLayoutPanel2;
-        private Label label18;
-        private Label label19;
-        private Label label20;
-        private Label label21;
-        private Label label22;
-        private Label label23;
-        private Label label24;
-        private TextBox textBox4;
-        private TextBox textBox16;
-        private TextBox textBox17;
-        private TextBox textBox18;
-        private TextBox textBox19;
-        private TextBox textBox20;
-        private TextBox textBox21;
-        private TableLayoutPanel tableLayoutPanel3;
-        private Label label32;
-        private Button button1;
+        private Label BrandLabel;
+        private Label BrandModelLabel;
+        private Label FullNameLabel;
+        private ComboBox ChannelComboBox;
+        private Label ChannelLabel;
+        private Label ParameterLabel;
+        private Label ParameterTextLabel;
+        private Label UnitLabel;
+        private Label UnitTextLabel;
+        private Label IsActiveLabel;
+        private Label ChannelMinValueLabel;
+        private Label ChannelMaxValueLabel;
+        private Label ChannelNumberLabel;
+        private Label CalibrationFormulaALabel;
+        private Label CalibrationFormulaBLabel;
+        private Label SerialNumberLabel;
+        private TextBox FullNameTextBox;
+        private TextBox BrandTextBox;
+        private TextBox BrandModelTextBox;
+        private TextBox ParameterTextBox;
+        private TextBox ParameterTextTextBox;
+        private TextBox UnitTextBox;
+        private TextBox UnitTextTextBox;
+        private TextBox IsActiveTextBox;
+        private TextBox ChannelMinValueTextBox;
+        private TextBox ChannelMaxValueTextBox;
+        private TextBox ChannelNumberTextBox;
+        private TextBox CalibrationFormulaATextBox;
+        private TextBox CalibrationFormulaBTextBox;
+        private TextBox SerialNumberTextBox;
+        private TableLayoutPanel UpdateChannelContentTableLayoutPanel;
+        private Label UnitUpdateLabel;
+        private Label IsActiveUpdateLabel;
+        private Label ChannelMinValueUpdateLabel;
+        private Label ChannelMaxValueUpdateLabel;
+        private Label ChannelNumberUpdateLabel;
+        private Label CalibrationFormulaAUpdateLabel;
+        private Label CalibrationFormulaBUpdateLabel;
+        private TextBox ChannelMinValueUpdateTextBox;
+        private TextBox UnitUpdateTextBox;
+        private TextBox IsActiveUpdateTextBox;
+        private TextBox ChannelMaxValueUpdateTextBox;
+        private TextBox ChannelNumberUpdateTextBox;
+        private TextBox CalibrationFormulaAUpdateTextBox;
+        private TextBox CalibrationFormulaBUpdateTextBox;
+        private TableLayoutPanel UpdateChannelHeaderTableLayoutPanel;
+        private Label UpdateChannelTitleLabel;
+        private Button SaveChannelButton;
     }
 }

--- a/WinUI/Pages/Settings/DatabaseSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/DatabaseSettingsPage.Designer.cs
@@ -30,28 +30,28 @@
         {
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
             StationSettingsContentTableLayoutPanel = new TableLayoutPanel();
-            label18 = new Label();
-            textBox15 = new TextBox();
-            textBox16 = new TextBox();
-            textBox20 = new TextBox();
-            label19 = new Label();
-            label3 = new Label();
-            tableLayoutPanel5 = new TableLayoutPanel();
-            label2 = new Label();
-            SaveButton = new Button();
-            tableLayoutPanel4 = new TableLayoutPanel();
-            label1 = new Label();
-            FetchButton = new Button();
+            ConnectedServerLabel = new Label();
+            ConnectedServerTextBox = new TextBox();
+            StorageUsageTextBox = new TextBox();
+            DatabaseNameTextBox = new TextBox();
+            StorageUsageLabel = new Label();
+            DatabaseNameLabel = new Label();
+            DatabaseInfoHeaderTableLayoutPanel = new TableLayoutPanel();
+            DatabaseInfoLabel = new Label();
+            RefreshDatabaseInfoButton = new Button();
+            DatabaseSettingsHeaderTableLayoutPanel = new TableLayoutPanel();
+            DatabaseSettingsLabel = new Label();
+            SaveDatabaseButton = new Button();
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
             StationInfoContentTableLayoutPanel = new TableLayoutPanel();
-            label4 = new Label();
-            textBox1 = new TextBox();
-            label5 = new Label();
-            comboBox1 = new ComboBox();
+            ServerAddressLabel = new Label();
+            ServerAddressTextBox = new TextBox();
+            LogLevelLabel = new Label();
+            LogLevelComboBox = new ComboBox();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
             StationSettingsContentTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel5.SuspendLayout();
-            tableLayoutPanel4.SuspendLayout();
+            DatabaseInfoHeaderTableLayoutPanel.SuspendLayout();
+            DatabaseSettingsHeaderTableLayoutPanel.SuspendLayout();
             StationInfoBgTableLayoutPanel.SuspendLayout();
             StationInfoContentTableLayoutPanel.SuspendLayout();
             SuspendLayout();
@@ -62,8 +62,8 @@
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.Controls.Add(StationSettingsContentTableLayoutPanel, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel5, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(DatabaseInfoHeaderTableLayoutPanel, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(DatabaseSettingsHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -81,12 +81,12 @@
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationSettingsContentTableLayoutPanel.Controls.Add(label18, 0, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox15, 1, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox16, 1, 2);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox20, 1, 1);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label19, 0, 2);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label3, 0, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectedServerLabel, 0, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectedServerTextBox, 1, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(StorageUsageTextBox, 1, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(DatabaseNameTextBox, 1, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(StorageUsageLabel, 0, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(DatabaseNameLabel, 0, 1);
             StationSettingsContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsContentTableLayoutPanel.Location = new Point(547, 40);
             StationSettingsContentTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
@@ -110,147 +110,147 @@
             StationSettingsContentTableLayoutPanel.Size = new Size(542, 463);
             StationSettingsContentTableLayoutPanel.TabIndex = 6;
             // 
-            // label18
+            // ConnectedServerLabel
             // 
-            label18.Anchor = AnchorStyles.Left;
-            label18.AutoSize = true;
-            label18.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label18.ForeColor = Color.FromArgb(64, 64, 64);
-            label18.Location = new Point(18, 22);
-            label18.Name = "label18";
-            label18.Size = new Size(92, 16);
-            label18.TabIndex = 1;
-            label18.Text = "Bağlı Sunucu";
+            ConnectedServerLabel.Anchor = AnchorStyles.Left;
+            ConnectedServerLabel.AutoSize = true;
+            ConnectedServerLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConnectedServerLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConnectedServerLabel.Location = new Point(18, 22);
+            ConnectedServerLabel.Name = "ConnectedServerLabel";
+            ConnectedServerLabel.Size = new Size(92, 16);
+            ConnectedServerLabel.TabIndex = 1;
+            ConnectedServerLabel.Text = "Bağlı Sunucu";
             // 
-            // textBox15
+            // ConnectedServerTextBox
             // 
-            textBox15.Anchor = AnchorStyles.Left;
-            textBox15.Enabled = false;
-            textBox15.Location = new Point(234, 19);
-            textBox15.Name = "textBox15";
-            textBox15.PlaceholderText = "SQLExpress";
-            textBox15.Size = new Size(288, 23);
-            textBox15.TabIndex = 2;
+            ConnectedServerTextBox.Anchor = AnchorStyles.Left;
+            ConnectedServerTextBox.Enabled = false;
+            ConnectedServerTextBox.Location = new Point(234, 19);
+            ConnectedServerTextBox.Name = "ConnectedServerTextBox";
+            ConnectedServerTextBox.PlaceholderText = "SQLExpress";
+            ConnectedServerTextBox.Size = new Size(288, 23);
+            ConnectedServerTextBox.TabIndex = 2;
             // 
-            // textBox16
+            // StorageUsageTextBox
             // 
-            textBox16.Anchor = AnchorStyles.Left;
-            textBox16.Enabled = false;
-            textBox16.Location = new Point(234, 81);
-            textBox16.Name = "textBox16";
-            textBox16.PlaceholderText = "1.3 GB / 10 GB";
-            textBox16.Size = new Size(288, 23);
-            textBox16.TabIndex = 2;
+            StorageUsageTextBox.Anchor = AnchorStyles.Left;
+            StorageUsageTextBox.Enabled = false;
+            StorageUsageTextBox.Location = new Point(234, 81);
+            StorageUsageTextBox.Name = "StorageUsageTextBox";
+            StorageUsageTextBox.PlaceholderText = "1.3 GB / 10 GB";
+            StorageUsageTextBox.Size = new Size(288, 23);
+            StorageUsageTextBox.TabIndex = 2;
             // 
-            // textBox20
+            // DatabaseNameTextBox
             // 
-            textBox20.Anchor = AnchorStyles.Left;
-            textBox20.Enabled = false;
-            textBox20.Location = new Point(234, 50);
-            textBox20.Name = "textBox20";
-            textBox20.PlaceholderText = "IBKSContext";
-            textBox20.Size = new Size(288, 23);
-            textBox20.TabIndex = 2;
+            DatabaseNameTextBox.Anchor = AnchorStyles.Left;
+            DatabaseNameTextBox.Enabled = false;
+            DatabaseNameTextBox.Location = new Point(234, 50);
+            DatabaseNameTextBox.Name = "DatabaseNameTextBox";
+            DatabaseNameTextBox.PlaceholderText = "IBKSContext";
+            DatabaseNameTextBox.Size = new Size(288, 23);
+            DatabaseNameTextBox.TabIndex = 2;
             // 
-            // label19
+            // StorageUsageLabel
             // 
-            label19.Anchor = AnchorStyles.Left;
-            label19.AutoSize = true;
-            label19.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label19.ForeColor = Color.FromArgb(64, 64, 64);
-            label19.Location = new Point(18, 84);
-            label19.Name = "label19";
-            label19.Size = new Size(109, 16);
-            label19.TabIndex = 1;
-            label19.Text = "Depolama Alanı";
+            StorageUsageLabel.Anchor = AnchorStyles.Left;
+            StorageUsageLabel.AutoSize = true;
+            StorageUsageLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StorageUsageLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StorageUsageLabel.Location = new Point(18, 84);
+            StorageUsageLabel.Name = "StorageUsageLabel";
+            StorageUsageLabel.Size = new Size(109, 16);
+            StorageUsageLabel.TabIndex = 1;
+            StorageUsageLabel.Text = "Depolama Alanı";
             // 
-            // label3
+            // DatabaseNameLabel
             // 
-            label3.Anchor = AnchorStyles.Left;
-            label3.AutoSize = true;
-            label3.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label3.ForeColor = Color.FromArgb(64, 64, 64);
-            label3.Location = new Point(18, 53);
-            label3.Name = "label3";
-            label3.Size = new Size(97, 16);
-            label3.TabIndex = 1;
-            label3.Text = "Veritabanı Adı";
+            DatabaseNameLabel.Anchor = AnchorStyles.Left;
+            DatabaseNameLabel.AutoSize = true;
+            DatabaseNameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            DatabaseNameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            DatabaseNameLabel.Location = new Point(18, 53);
+            DatabaseNameLabel.Name = "DatabaseNameLabel";
+            DatabaseNameLabel.Size = new Size(97, 16);
+            DatabaseNameLabel.TabIndex = 1;
+            DatabaseNameLabel.Text = "Veritabanı Adı";
             // 
-            // tableLayoutPanel5
+            // DatabaseInfoHeaderTableLayoutPanel
             // 
-            tableLayoutPanel5.ColumnCount = 2;
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Controls.Add(label2, 0, 0);
-            tableLayoutPanel5.Controls.Add(SaveButton, 1, 0);
-            tableLayoutPanel5.Dock = DockStyle.Fill;
-            tableLayoutPanel5.Location = new Point(547, 0);
-            tableLayoutPanel5.Margin = new Padding(0);
-            tableLayoutPanel5.Name = "tableLayoutPanel5";
-            tableLayoutPanel5.RowCount = 1;
-            tableLayoutPanel5.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Size = new Size(547, 40);
-            tableLayoutPanel5.TabIndex = 4;
+            DatabaseInfoHeaderTableLayoutPanel.ColumnCount = 2;
+            DatabaseInfoHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            DatabaseInfoHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            DatabaseInfoHeaderTableLayoutPanel.Controls.Add(DatabaseInfoLabel, 0, 0);
+            DatabaseInfoHeaderTableLayoutPanel.Controls.Add(RefreshDatabaseInfoButton, 1, 0);
+            DatabaseInfoHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            DatabaseInfoHeaderTableLayoutPanel.Location = new Point(547, 0);
+            DatabaseInfoHeaderTableLayoutPanel.Margin = new Padding(0);
+            DatabaseInfoHeaderTableLayoutPanel.Name = "DatabaseInfoHeaderTableLayoutPanel";
+            DatabaseInfoHeaderTableLayoutPanel.RowCount = 1;
+            DatabaseInfoHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            DatabaseInfoHeaderTableLayoutPanel.Size = new Size(547, 40);
+            DatabaseInfoHeaderTableLayoutPanel.TabIndex = 4;
             // 
-            // label2
+            // DatabaseInfoLabel
             // 
-            label2.AutoSize = true;
-            label2.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label2.ForeColor = Color.FromArgb(64, 64, 64);
-            label2.Location = new Point(3, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(178, 22);
-            label2.TabIndex = 0;
-            label2.Text = "Veritabanı Bilgileri";
+            DatabaseInfoLabel.AutoSize = true;
+            DatabaseInfoLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            DatabaseInfoLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            DatabaseInfoLabel.Location = new Point(3, 0);
+            DatabaseInfoLabel.Name = "DatabaseInfoLabel";
+            DatabaseInfoLabel.Size = new Size(178, 22);
+            DatabaseInfoLabel.TabIndex = 0;
+            DatabaseInfoLabel.Text = "Veritabanı Bilgileri";
             // 
-            // SaveButton
+            // RefreshDatabaseInfoButton
             // 
-            SaveButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            SaveButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            SaveButton.Location = new Point(452, 3);
-            SaveButton.Name = "SaveButton";
-            SaveButton.Size = new Size(92, 32);
-            SaveButton.TabIndex = 2;
-            SaveButton.Text = "Yenile";
-            SaveButton.UseVisualStyleBackColor = true;
+            RefreshDatabaseInfoButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            RefreshDatabaseInfoButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            RefreshDatabaseInfoButton.Location = new Point(452, 3);
+            RefreshDatabaseInfoButton.Name = "RefreshDatabaseInfoButton";
+            RefreshDatabaseInfoButton.Size = new Size(92, 32);
+            RefreshDatabaseInfoButton.TabIndex = 2;
+            RefreshDatabaseInfoButton.Text = "Yenile";
+            RefreshDatabaseInfoButton.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel4
+            // DatabaseSettingsHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 2;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Controls.Add(FetchButton, 1, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            DatabaseSettingsHeaderTableLayoutPanel.ColumnCount = 2;
+            DatabaseSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            DatabaseSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            DatabaseSettingsHeaderTableLayoutPanel.Controls.Add(DatabaseSettingsLabel, 0, 0);
+            DatabaseSettingsHeaderTableLayoutPanel.Controls.Add(SaveDatabaseButton, 1, 0);
+            DatabaseSettingsHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            DatabaseSettingsHeaderTableLayoutPanel.Location = new Point(0, 0);
+            DatabaseSettingsHeaderTableLayoutPanel.Margin = new Padding(0);
+            DatabaseSettingsHeaderTableLayoutPanel.Name = "DatabaseSettingsHeaderTableLayoutPanel";
+            DatabaseSettingsHeaderTableLayoutPanel.RowCount = 1;
+            DatabaseSettingsHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            DatabaseSettingsHeaderTableLayoutPanel.Size = new Size(547, 40);
+            DatabaseSettingsHeaderTableLayoutPanel.TabIndex = 3;
             // 
-            // label1
+            // DatabaseSettingsLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(178, 22);
-            label1.TabIndex = 0;
-            label1.Text = "Veritabanı Ayarları";
+            DatabaseSettingsLabel.AutoSize = true;
+            DatabaseSettingsLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            DatabaseSettingsLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            DatabaseSettingsLabel.Location = new Point(3, 0);
+            DatabaseSettingsLabel.Name = "DatabaseSettingsLabel";
+            DatabaseSettingsLabel.Size = new Size(178, 22);
+            DatabaseSettingsLabel.TabIndex = 0;
+            DatabaseSettingsLabel.Text = "Veritabanı Ayarları";
             // 
-            // FetchButton
+            // SaveDatabaseButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(452, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Kaydet";
-            FetchButton.UseVisualStyleBackColor = true;
+            SaveDatabaseButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveDatabaseButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveDatabaseButton.Location = new Point(452, 3);
+            SaveDatabaseButton.Name = "SaveDatabaseButton";
+            SaveDatabaseButton.Size = new Size(92, 32);
+            SaveDatabaseButton.TabIndex = 2;
+            SaveDatabaseButton.Text = "Kaydet";
+            SaveDatabaseButton.UseVisualStyleBackColor = true;
             // 
             // StationInfoBgTableLayoutPanel
             // 
@@ -274,10 +274,10 @@
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationInfoContentTableLayoutPanel.Controls.Add(label4, 0, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox1, 1, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(label5, 0, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(comboBox1, 1, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(ServerAddressLabel, 0, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(ServerAddressTextBox, 1, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(LogLevelLabel, 0, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(LogLevelComboBox, 1, 1);
             StationInfoContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoContentTableLayoutPanel.Location = new Point(1, 1);
             StationInfoContentTableLayoutPanel.Margin = new Padding(1);
@@ -301,48 +301,48 @@
             StationInfoContentTableLayoutPanel.Size = new Size(540, 461);
             StationInfoContentTableLayoutPanel.TabIndex = 2;
             // 
-            // label4
+            // ServerAddressLabel
             // 
-            label4.Anchor = AnchorStyles.Left;
-            label4.AutoSize = true;
-            label4.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label4.ForeColor = Color.FromArgb(64, 64, 64);
-            label4.Location = new Point(18, 22);
-            label4.Name = "label4";
-            label4.Size = new Size(99, 16);
-            label4.TabIndex = 1;
-            label4.Text = "Sunucu Adresi";
+            ServerAddressLabel.Anchor = AnchorStyles.Left;
+            ServerAddressLabel.AutoSize = true;
+            ServerAddressLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ServerAddressLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ServerAddressLabel.Location = new Point(18, 22);
+            ServerAddressLabel.Name = "ServerAddressLabel";
+            ServerAddressLabel.Size = new Size(99, 16);
+            ServerAddressLabel.TabIndex = 1;
+            ServerAddressLabel.Text = "Sunucu Adresi";
             // 
-            // textBox1
+            // ServerAddressTextBox
             // 
-            textBox1.Anchor = AnchorStyles.Left;
-            textBox1.Location = new Point(234, 19);
-            textBox1.Name = "textBox1";
-            textBox1.PlaceholderText = "localhost";
-            textBox1.Size = new Size(288, 23);
-            textBox1.TabIndex = 2;
+            ServerAddressTextBox.Anchor = AnchorStyles.Left;
+            ServerAddressTextBox.Location = new Point(234, 19);
+            ServerAddressTextBox.Name = "ServerAddressTextBox";
+            ServerAddressTextBox.PlaceholderText = "localhost";
+            ServerAddressTextBox.Size = new Size(288, 23);
+            ServerAddressTextBox.TabIndex = 2;
             // 
-            // label5
+            // LogLevelLabel
             // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label5.ForeColor = Color.FromArgb(64, 64, 64);
-            label5.Location = new Point(18, 53);
-            label5.Name = "label5";
-            label5.Size = new Size(88, 16);
-            label5.TabIndex = 1;
-            label5.Text = "Log Seviyesi";
+            LogLevelLabel.Anchor = AnchorStyles.Left;
+            LogLevelLabel.AutoSize = true;
+            LogLevelLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            LogLevelLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            LogLevelLabel.Location = new Point(18, 53);
+            LogLevelLabel.Name = "LogLevelLabel";
+            LogLevelLabel.Size = new Size(88, 16);
+            LogLevelLabel.TabIndex = 1;
+            LogLevelLabel.Text = "Log Seviyesi";
             // 
-            // comboBox1
+            // LogLevelComboBox
             // 
-            comboBox1.DropDownStyle = ComboBoxStyle.DropDownList;
-            comboBox1.FormattingEnabled = true;
-            comboBox1.Items.AddRange(new object[] { "Bilgi", "Uyarı", "Hata" });
-            comboBox1.Location = new Point(234, 49);
-            comboBox1.Name = "comboBox1";
-            comboBox1.Size = new Size(288, 23);
-            comboBox1.TabIndex = 3;
+            LogLevelComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            LogLevelComboBox.FormattingEnabled = true;
+            LogLevelComboBox.Items.AddRange(new object[] { "Bilgi", "Uyarı", "Hata" });
+            LogLevelComboBox.Location = new Point(234, 49);
+            LogLevelComboBox.Name = "LogLevelComboBox";
+            LogLevelComboBox.Size = new Size(288, 23);
+            LogLevelComboBox.TabIndex = 3;
             // 
             // DatabaseSettingsPage
             // 
@@ -355,10 +355,10 @@
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
             StationSettingsContentTableLayoutPanel.ResumeLayout(false);
             StationSettingsContentTableLayoutPanel.PerformLayout();
-            tableLayoutPanel5.ResumeLayout(false);
-            tableLayoutPanel5.PerformLayout();
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            DatabaseInfoHeaderTableLayoutPanel.ResumeLayout(false);
+            DatabaseInfoHeaderTableLayoutPanel.PerformLayout();
+            DatabaseSettingsHeaderTableLayoutPanel.ResumeLayout(false);
+            DatabaseSettingsHeaderTableLayoutPanel.PerformLayout();
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.PerformLayout();
@@ -368,23 +368,23 @@
         #endregion
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
         private TableLayoutPanel StationSettingsContentTableLayoutPanel;
-        private Label label18;
-        private Label label19;
-        private TextBox textBox15;
-        private TextBox textBox16;
-        private TextBox textBox20;
-        private TableLayoutPanel tableLayoutPanel5;
-        private Label label2;
-        private TableLayoutPanel tableLayoutPanel4;
-        private Label label1;
-        private Button FetchButton;
+        private Label ConnectedServerLabel;
+        private Label StorageUsageLabel;
+        private TextBox ConnectedServerTextBox;
+        private TextBox StorageUsageTextBox;
+        private TextBox DatabaseNameTextBox;
+        private TableLayoutPanel DatabaseInfoHeaderTableLayoutPanel;
+        private Label DatabaseInfoLabel;
+        private TableLayoutPanel DatabaseSettingsHeaderTableLayoutPanel;
+        private Label DatabaseSettingsLabel;
+        private Button SaveDatabaseButton;
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
-        private Label label3;
-        private Button SaveButton;
+        private Label DatabaseNameLabel;
+        private Button RefreshDatabaseInfoButton;
         private TableLayoutPanel StationInfoContentTableLayoutPanel;
-        private Label label4;
-        private TextBox textBox1;
-        private Label label5;
-        private ComboBox comboBox1;
+        private Label ServerAddressLabel;
+        private TextBox ServerAddressTextBox;
+        private Label LogLevelLabel;
+        private ComboBox LogLevelComboBox;
     }
 }

--- a/WinUI/Pages/Settings/MailUserSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/MailUserSettingsPage.Designer.cs
@@ -29,26 +29,26 @@
         private void InitializeComponent()
         {
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
-            dataGridView1 = new DataGridView();
-            label1 = new Label();
-            FetchButton = new Button();
-            tableLayoutPanel4 = new TableLayoutPanel();
-            label2 = new Label();
-            SaveButton = new Button();
-            label18 = new Label();
-            textBox15 = new TextBox();
-            label19 = new Label();
-            label3 = new Label();
+            MailUsersDataGridView = new DataGridView();
+            MailUsersLabel = new Label();
+            RefreshUsersButton = new Button();
+            MailUsersHeaderTableLayoutPanel = new TableLayoutPanel();
+            EditUserLabel = new Label();
+            SaveUserButton = new Button();
+            UsernameLabel = new Label();
+            UsernameTextBox = new TextBox();
+            PasswordLabel = new Label();
+            EmailLabel = new Label();
             StationSettingsContentTableLayoutPanel = new TableLayoutPanel();
-            textBox2 = new TextBox();
-            textBox3 = new TextBox();
-            tableLayoutPanel5 = new TableLayoutPanel();
+            EmailTextBox = new TextBox();
+            PasswordTextBox = new TextBox();
+            EditUserHeaderTableLayoutPanel = new TableLayoutPanel();
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
             StationInfoBgTableLayoutPanel.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)dataGridView1).BeginInit();
-            tableLayoutPanel4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)MailUsersDataGridView).BeginInit();
+            MailUsersHeaderTableLayoutPanel.SuspendLayout();
             StationSettingsContentTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel5.SuspendLayout();
+            EditUserHeaderTableLayoutPanel.SuspendLayout();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
             SuspendLayout();
             // 
@@ -57,7 +57,7 @@
             StationInfoBgTableLayoutPanel.BackColor = Color.FromArgb(235, 235, 235);
             StationInfoBgTableLayoutPanel.ColumnCount = 1;
             StationInfoBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            StationInfoBgTableLayoutPanel.Controls.Add(dataGridView1, 0, 0);
+            StationInfoBgTableLayoutPanel.Controls.Add(MailUsersDataGridView, 0, 0);
             StationInfoBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoBgTableLayoutPanel.Location = new Point(0, 40);
             StationInfoBgTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
@@ -67,122 +67,122 @@
             StationInfoBgTableLayoutPanel.Size = new Size(542, 463);
             StationInfoBgTableLayoutPanel.TabIndex = 5;
             // 
-            // dataGridView1
+            // MailUsersDataGridView
             // 
-            dataGridView1.BackgroundColor = Color.White;
-            dataGridView1.BorderStyle = BorderStyle.None;
-            dataGridView1.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridView1.Dock = DockStyle.Fill;
-            dataGridView1.Location = new Point(3, 3);
-            dataGridView1.Name = "dataGridView1";
-            dataGridView1.Size = new Size(536, 457);
-            dataGridView1.TabIndex = 0;
+            MailUsersDataGridView.BackgroundColor = Color.White;
+            MailUsersDataGridView.BorderStyle = BorderStyle.None;
+            MailUsersDataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            MailUsersDataGridView.Dock = DockStyle.Fill;
+            MailUsersDataGridView.Location = new Point(3, 3);
+            MailUsersDataGridView.Name = "MailUsersDataGridView";
+            MailUsersDataGridView.Size = new Size(536, 457);
+            MailUsersDataGridView.TabIndex = 0;
             // 
-            // label1
+            // MailUsersLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(162, 22);
-            label1.TabIndex = 0;
-            label1.Text = "Mail Kullanıcıları";
+            MailUsersLabel.AutoSize = true;
+            MailUsersLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            MailUsersLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            MailUsersLabel.Location = new Point(3, 0);
+            MailUsersLabel.Name = "MailUsersLabel";
+            MailUsersLabel.Size = new Size(162, 22);
+            MailUsersLabel.TabIndex = 0;
+            MailUsersLabel.Text = "Mail Kullanıcıları";
             // 
-            // FetchButton
+            // RefreshUsersButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(452, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Yenile";
-            FetchButton.TextImageRelation = TextImageRelation.ImageAboveText;
-            FetchButton.UseVisualStyleBackColor = true;
+            RefreshUsersButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            RefreshUsersButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            RefreshUsersButton.Location = new Point(452, 3);
+            RefreshUsersButton.Name = "RefreshUsersButton";
+            RefreshUsersButton.Size = new Size(92, 32);
+            RefreshUsersButton.TabIndex = 2;
+            RefreshUsersButton.Text = "Yenile";
+            RefreshUsersButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            RefreshUsersButton.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel4
+            // MailUsersHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 2;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Controls.Add(FetchButton, 1, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            MailUsersHeaderTableLayoutPanel.ColumnCount = 2;
+            MailUsersHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            MailUsersHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            MailUsersHeaderTableLayoutPanel.Controls.Add(MailUsersLabel, 0, 0);
+            MailUsersHeaderTableLayoutPanel.Controls.Add(RefreshUsersButton, 1, 0);
+            MailUsersHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            MailUsersHeaderTableLayoutPanel.Location = new Point(0, 0);
+            MailUsersHeaderTableLayoutPanel.Margin = new Padding(0);
+            MailUsersHeaderTableLayoutPanel.Name = "MailUsersHeaderTableLayoutPanel";
+            MailUsersHeaderTableLayoutPanel.RowCount = 1;
+            MailUsersHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            MailUsersHeaderTableLayoutPanel.Size = new Size(547, 40);
+            MailUsersHeaderTableLayoutPanel.TabIndex = 3;
             // 
-            // label2
+            // EditUserLabel
             // 
-            label2.AutoSize = true;
-            label2.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label2.ForeColor = Color.FromArgb(64, 64, 64);
-            label2.Location = new Point(3, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(170, 22);
-            label2.TabIndex = 0;
-            label2.Text = "Kullanıcı Düzenle";
+            EditUserLabel.AutoSize = true;
+            EditUserLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            EditUserLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            EditUserLabel.Location = new Point(3, 0);
+            EditUserLabel.Name = "EditUserLabel";
+            EditUserLabel.Size = new Size(170, 22);
+            EditUserLabel.TabIndex = 0;
+            EditUserLabel.Text = "Kullanıcı Düzenle";
             // 
-            // SaveButton
+            // SaveUserButton
             // 
-            SaveButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            SaveButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            SaveButton.Location = new Point(452, 3);
-            SaveButton.Name = "SaveButton";
-            SaveButton.Size = new Size(92, 32);
-            SaveButton.TabIndex = 2;
-            SaveButton.Text = "Kaydet";
-            SaveButton.UseVisualStyleBackColor = true;
+            SaveUserButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveUserButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveUserButton.Location = new Point(452, 3);
+            SaveUserButton.Name = "SaveUserButton";
+            SaveUserButton.Size = new Size(92, 32);
+            SaveUserButton.TabIndex = 2;
+            SaveUserButton.Text = "Kaydet";
+            SaveUserButton.UseVisualStyleBackColor = true;
             // 
-            // label18
+            // UsernameLabel
             // 
-            label18.Anchor = AnchorStyles.Left;
-            label18.AutoSize = true;
-            label18.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label18.ForeColor = Color.FromArgb(64, 64, 64);
-            label18.Location = new Point(18, 22);
-            label18.Name = "label18";
-            label18.Size = new Size(88, 16);
-            label18.TabIndex = 1;
-            label18.Text = "Kullanıcı Adı";
+            UsernameLabel.Anchor = AnchorStyles.Left;
+            UsernameLabel.AutoSize = true;
+            UsernameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            UsernameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            UsernameLabel.Location = new Point(18, 22);
+            UsernameLabel.Name = "UsernameLabel";
+            UsernameLabel.Size = new Size(88, 16);
+            UsernameLabel.TabIndex = 1;
+            UsernameLabel.Text = "Kullanıcı Adı";
             // 
-            // textBox15
+            // UsernameTextBox
             // 
-            textBox15.Anchor = AnchorStyles.Left;
-            textBox15.Location = new Point(234, 19);
-            textBox15.Name = "textBox15";
-            textBox15.PlaceholderText = "kullanıcı adı";
-            textBox15.Size = new Size(288, 23);
-            textBox15.TabIndex = 2;
+            UsernameTextBox.Anchor = AnchorStyles.Left;
+            UsernameTextBox.Location = new Point(234, 19);
+            UsernameTextBox.Name = "UsernameTextBox";
+            UsernameTextBox.PlaceholderText = "kullanıcı adı";
+            UsernameTextBox.Size = new Size(288, 23);
+            UsernameTextBox.TabIndex = 2;
             // 
-            // label19
+            // PasswordLabel
             // 
-            label19.Anchor = AnchorStyles.Left;
-            label19.AutoSize = true;
-            label19.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label19.ForeColor = Color.FromArgb(64, 64, 64);
-            label19.Location = new Point(18, 84);
-            label19.Name = "label19";
-            label19.Size = new Size(37, 16);
-            label19.TabIndex = 1;
-            label19.Text = "Şifre";
+            PasswordLabel.Anchor = AnchorStyles.Left;
+            PasswordLabel.AutoSize = true;
+            PasswordLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            PasswordLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            PasswordLabel.Location = new Point(18, 84);
+            PasswordLabel.Name = "PasswordLabel";
+            PasswordLabel.Size = new Size(37, 16);
+            PasswordLabel.TabIndex = 1;
+            PasswordLabel.Text = "Şifre";
             // 
-            // label3
+            // EmailLabel
             // 
-            label3.Anchor = AnchorStyles.Left;
-            label3.AutoSize = true;
-            label3.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label3.ForeColor = Color.FromArgb(64, 64, 64);
-            label3.Location = new Point(18, 53);
-            label3.Name = "label3";
-            label3.Size = new Size(34, 16);
-            label3.TabIndex = 1;
-            label3.Text = "Mail";
+            EmailLabel.Anchor = AnchorStyles.Left;
+            EmailLabel.AutoSize = true;
+            EmailLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            EmailLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            EmailLabel.Location = new Point(18, 53);
+            EmailLabel.Name = "EmailLabel";
+            EmailLabel.Size = new Size(34, 16);
+            EmailLabel.TabIndex = 1;
+            EmailLabel.Text = "Mail";
             // 
             // StationSettingsContentTableLayoutPanel
             // 
@@ -191,12 +191,12 @@
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationSettingsContentTableLayoutPanel.Controls.Add(label18, 0, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox15, 1, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label19, 0, 2);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label3, 0, 1);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox2, 1, 1);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox3, 1, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(UsernameLabel, 0, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(UsernameTextBox, 1, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(PasswordLabel, 0, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(EmailLabel, 0, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(EmailTextBox, 1, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(PasswordTextBox, 1, 2);
             StationSettingsContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsContentTableLayoutPanel.Location = new Point(547, 40);
             StationSettingsContentTableLayoutPanel.Margin = new Padding(0, 0, 5, 0);
@@ -220,39 +220,39 @@
             StationSettingsContentTableLayoutPanel.Size = new Size(542, 463);
             StationSettingsContentTableLayoutPanel.TabIndex = 6;
             // 
-            // textBox2
+            // EmailTextBox
             // 
-            textBox2.Anchor = AnchorStyles.Left;
-            textBox2.Location = new Point(234, 50);
-            textBox2.Name = "textBox2";
-            textBox2.PlaceholderText = "ornek@iski.gov.tr";
-            textBox2.Size = new Size(288, 23);
-            textBox2.TabIndex = 2;
+            EmailTextBox.Anchor = AnchorStyles.Left;
+            EmailTextBox.Location = new Point(234, 50);
+            EmailTextBox.Name = "EmailTextBox";
+            EmailTextBox.PlaceholderText = "ornek@iski.gov.tr";
+            EmailTextBox.Size = new Size(288, 23);
+            EmailTextBox.TabIndex = 2;
             // 
-            // textBox3
+            // PasswordTextBox
             // 
-            textBox3.Anchor = AnchorStyles.Left;
-            textBox3.Location = new Point(234, 81);
-            textBox3.Name = "textBox3";
-            textBox3.PlaceholderText = "sifre";
-            textBox3.Size = new Size(288, 23);
-            textBox3.TabIndex = 2;
+            PasswordTextBox.Anchor = AnchorStyles.Left;
+            PasswordTextBox.Location = new Point(234, 81);
+            PasswordTextBox.Name = "PasswordTextBox";
+            PasswordTextBox.PlaceholderText = "sifre";
+            PasswordTextBox.Size = new Size(288, 23);
+            PasswordTextBox.TabIndex = 2;
             // 
-            // tableLayoutPanel5
+            // EditUserHeaderTableLayoutPanel
             // 
-            tableLayoutPanel5.ColumnCount = 2;
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Controls.Add(label2, 0, 0);
-            tableLayoutPanel5.Controls.Add(SaveButton, 1, 0);
-            tableLayoutPanel5.Dock = DockStyle.Fill;
-            tableLayoutPanel5.Location = new Point(547, 0);
-            tableLayoutPanel5.Margin = new Padding(0);
-            tableLayoutPanel5.Name = "tableLayoutPanel5";
-            tableLayoutPanel5.RowCount = 1;
-            tableLayoutPanel5.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Size = new Size(547, 40);
-            tableLayoutPanel5.TabIndex = 4;
+            EditUserHeaderTableLayoutPanel.ColumnCount = 2;
+            EditUserHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            EditUserHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            EditUserHeaderTableLayoutPanel.Controls.Add(EditUserLabel, 0, 0);
+            EditUserHeaderTableLayoutPanel.Controls.Add(SaveUserButton, 1, 0);
+            EditUserHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            EditUserHeaderTableLayoutPanel.Location = new Point(547, 0);
+            EditUserHeaderTableLayoutPanel.Margin = new Padding(0);
+            EditUserHeaderTableLayoutPanel.Name = "EditUserHeaderTableLayoutPanel";
+            EditUserHeaderTableLayoutPanel.RowCount = 1;
+            EditUserHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            EditUserHeaderTableLayoutPanel.Size = new Size(547, 40);
+            EditUserHeaderTableLayoutPanel.TabIndex = 4;
             // 
             // StationSettingsBgTableLayoutPanel
             // 
@@ -260,8 +260,8 @@
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.Controls.Add(StationSettingsContentTableLayoutPanel, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel5, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(EditUserHeaderTableLayoutPanel, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(MailUsersHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -281,33 +281,33 @@
             Padding = new Padding(0, 15, 0, 15);
             Size = new Size(1094, 533);
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)dataGridView1).EndInit();
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)MailUsersDataGridView).EndInit();
+            MailUsersHeaderTableLayoutPanel.ResumeLayout(false);
+            MailUsersHeaderTableLayoutPanel.PerformLayout();
             StationSettingsContentTableLayoutPanel.ResumeLayout(false);
             StationSettingsContentTableLayoutPanel.PerformLayout();
-            tableLayoutPanel5.ResumeLayout(false);
-            tableLayoutPanel5.PerformLayout();
+            EditUserHeaderTableLayoutPanel.ResumeLayout(false);
+            EditUserHeaderTableLayoutPanel.PerformLayout();
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
             ResumeLayout(false);
         }
 
         #endregion
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
-        private Label label1;
-        private Button FetchButton;
-        private TableLayoutPanel tableLayoutPanel4;
-        private Label label2;
-        private Button SaveButton;
-        private Label label18;
-        private TextBox textBox15;
-        private Label label19;
-        private Label label3;
+        private Label MailUsersLabel;
+        private Button RefreshUsersButton;
+        private TableLayoutPanel MailUsersHeaderTableLayoutPanel;
+        private Label EditUserLabel;
+        private Button SaveUserButton;
+        private Label UsernameLabel;
+        private TextBox UsernameTextBox;
+        private Label PasswordLabel;
+        private Label EmailLabel;
         private TableLayoutPanel StationSettingsContentTableLayoutPanel;
-        private TableLayoutPanel tableLayoutPanel5;
+        private TableLayoutPanel EditUserHeaderTableLayoutPanel;
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
-        private TextBox textBox2;
-        private TextBox textBox3;
-        private DataGridView dataGridView1;
+        private TextBox EmailTextBox;
+        private TextBox PasswordTextBox;
+        private DataGridView MailUsersDataGridView;
     }
 }

--- a/WinUI/Pages/Settings/StationSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.Designer.cs
@@ -30,56 +30,56 @@
         {
             StationSettingsBgTableLayoutPanel = new TableLayoutPanel();
             StationSettingsContentTableLayoutPanel = new TableLayoutPanel();
-            label18 = new Label();
-            label19 = new Label();
-            label20 = new Label();
-            label21 = new Label();
-            textBox15 = new TextBox();
-            textBox16 = new TextBox();
-            textBox17 = new TextBox();
-            textBox20 = new TextBox();
-            label22 = new Label();
-            textBox18 = new TextBox();
-            tableLayoutPanel5 = new TableLayoutPanel();
-            label2 = new Label();
-            SaveButton = new Button();
-            tableLayoutPanel4 = new TableLayoutPanel();
-            label1 = new Label();
-            FetchButton = new Button();
+            StationIdSettingLabel = new Label();
+            ConnectionUserLabel = new Label();
+            ConnectionPasswordLabel = new Label();
+            ConnectionDomainAddressLabel = new Label();
+            StationIdSettingTextBox = new TextBox();
+            ConnectionPasswordTextBox = new TextBox();
+            ConnectionDomainAddressTextBox = new TextBox();
+            ConnectionUserTextBox = new TextBox();
+            ConnectionPortLabel = new Label();
+            ConnectionPortTextBox = new TextBox();
+            StationSettingsHeaderTableLayoutPanel = new TableLayoutPanel();
+            StationSettingsLabel = new Label();
+            SaveStationSettingsButton = new Button();
+            StationInfoHeaderTableLayoutPanel = new TableLayoutPanel();
+            StationInfoLabel = new Label();
+            FetchStationButton = new Button();
             StationInfoBgTableLayoutPanel = new TableLayoutPanel();
             StationInfoContentTableLayoutPanel = new TableLayoutPanel();
-            label4 = new Label();
-            label5 = new Label();
-            label6 = new Label();
-            label7 = new Label();
-            label8 = new Label();
-            label9 = new Label();
-            label10 = new Label();
-            label11 = new Label();
-            label12 = new Label();
-            label13 = new Label();
-            label14 = new Label();
-            label15 = new Label();
-            label16 = new Label();
-            label17 = new Label();
-            textBox1 = new TextBox();
-            textBox5 = new TextBox();
-            textBox2 = new TextBox();
-            textBox6 = new TextBox();
-            textBox7 = new TextBox();
-            textBox8 = new TextBox();
-            textBox3 = new TextBox();
-            textBox4 = new TextBox();
-            textBox9 = new TextBox();
-            textBox10 = new TextBox();
-            textBox11 = new TextBox();
-            textBox12 = new TextBox();
-            textBox13 = new TextBox();
-            textBox14 = new TextBox();
+            StationIdLabel = new Label();
+            CodeLabel = new Label();
+            StationNameLabel = new Label();
+            DataPeriodLabel = new Label();
+            LastDataDateLabel = new Label();
+            CabinSoftwareAddressLabel = new Label();
+            CabinSoftwarePortLabel = new Label();
+            CabinSoftwareUsernameLabel = new Label();
+            CabinSoftwarePasswordLabel = new Label();
+            OrganizationLabel = new Label();
+            StationSetupDateLabel = new Label();
+            SoftwareSetupDateLabel = new Label();
+            StationAddressLabel = new Label();
+            SoftwareLabel = new Label();
+            StationIdTextBox = new TextBox();
+            StationNameTextBox = new TextBox();
+            DataPeriodTextBox = new TextBox();
+            LastDataDateTextBox = new TextBox();
+            CabinSoftwareAddressTextBox = new TextBox();
+            CodeTextBox = new TextBox();
+            CabinSoftwarePortTextBox = new TextBox();
+            CabinSoftwareUsernameTextBox = new TextBox();
+            CabinSoftwarePasswordTextBox = new TextBox();
+            OrganizationTextBox = new TextBox();
+            StationSetupDateTextBox = new TextBox();
+            SoftwareSetupDateTextBox = new TextBox();
+            StationAddressTextBox = new TextBox();
+            SoftwareTextBox = new TextBox();
             StationSettingsBgTableLayoutPanel.SuspendLayout();
             StationSettingsContentTableLayoutPanel.SuspendLayout();
-            tableLayoutPanel5.SuspendLayout();
-            tableLayoutPanel4.SuspendLayout();
+            StationSettingsHeaderTableLayoutPanel.SuspendLayout();
+            StationInfoHeaderTableLayoutPanel.SuspendLayout();
             StationInfoBgTableLayoutPanel.SuspendLayout();
             StationInfoContentTableLayoutPanel.SuspendLayout();
             SuspendLayout();
@@ -90,8 +90,8 @@
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             StationSettingsBgTableLayoutPanel.Controls.Add(StationSettingsContentTableLayoutPanel, 1, 1);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel5, 1, 0);
-            StationSettingsBgTableLayoutPanel.Controls.Add(tableLayoutPanel4, 0, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(StationSettingsHeaderTableLayoutPanel, 1, 0);
+            StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoHeaderTableLayoutPanel, 0, 0);
             StationSettingsBgTableLayoutPanel.Controls.Add(StationInfoBgTableLayoutPanel, 0, 1);
             StationSettingsBgTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsBgTableLayoutPanel.Location = new Point(0, 15);
@@ -109,16 +109,16 @@
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationSettingsContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationSettingsContentTableLayoutPanel.Controls.Add(label18, 0, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label19, 0, 1);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label20, 0, 2);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label21, 0, 3);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox15, 1, 0);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox16, 1, 2);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox17, 1, 3);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox20, 1, 1);
-            StationSettingsContentTableLayoutPanel.Controls.Add(label22, 0, 4);
-            StationSettingsContentTableLayoutPanel.Controls.Add(textBox18, 1, 4);
+            StationSettingsContentTableLayoutPanel.Controls.Add(StationIdSettingLabel, 0, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionUserLabel, 0, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionPasswordLabel, 0, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionDomainAddressLabel, 0, 3);
+            StationSettingsContentTableLayoutPanel.Controls.Add(StationIdSettingTextBox, 1, 0);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionPasswordTextBox, 1, 2);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionDomainAddressTextBox, 1, 3);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionUserTextBox, 1, 1);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionPortLabel, 0, 4);
+            StationSettingsContentTableLayoutPanel.Controls.Add(ConnectionPortTextBox, 1, 4);
             StationSettingsContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationSettingsContentTableLayoutPanel.Location = new Point(548, 41);
             StationSettingsContentTableLayoutPanel.Margin = new Padding(1, 1, 5, 1);
@@ -142,186 +142,186 @@
             StationSettingsContentTableLayoutPanel.Size = new Size(541, 461);
             StationSettingsContentTableLayoutPanel.TabIndex = 6;
             // 
-            // label18
+            // StationIdSettingLabel
             // 
-            label18.Anchor = AnchorStyles.Left;
-            label18.AutoSize = true;
-            label18.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label18.ForeColor = Color.FromArgb(64, 64, 64);
-            label18.Location = new Point(18, 22);
-            label18.Name = "label18";
-            label18.Size = new Size(64, 16);
-            label18.TabIndex = 1;
-            label18.Text = "StationId";
+            StationIdSettingLabel.Anchor = AnchorStyles.Left;
+            StationIdSettingLabel.AutoSize = true;
+            StationIdSettingLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationIdSettingLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationIdSettingLabel.Location = new Point(18, 22);
+            StationIdSettingLabel.Name = "StationIdSettingLabel";
+            StationIdSettingLabel.Size = new Size(64, 16);
+            StationIdSettingLabel.TabIndex = 1;
+            StationIdSettingLabel.Text = "StationId";
             // 
-            // label19
+            // ConnectionUserLabel
             // 
-            label19.Anchor = AnchorStyles.Left;
-            label19.AutoSize = true;
-            label19.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label19.ForeColor = Color.FromArgb(64, 64, 64);
-            label19.Location = new Point(18, 53);
-            label19.Name = "label19";
-            label19.Size = new Size(107, 16);
-            label19.TabIndex = 1;
-            label19.Text = "ConnectionUser";
+            ConnectionUserLabel.Anchor = AnchorStyles.Left;
+            ConnectionUserLabel.AutoSize = true;
+            ConnectionUserLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConnectionUserLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConnectionUserLabel.Location = new Point(18, 53);
+            ConnectionUserLabel.Name = "ConnectionUserLabel";
+            ConnectionUserLabel.Size = new Size(107, 16);
+            ConnectionUserLabel.TabIndex = 1;
+            ConnectionUserLabel.Text = "ConnectionUser";
             // 
-            // label20
+            // ConnectionPasswordLabel
             // 
-            label20.Anchor = AnchorStyles.Left;
-            label20.AutoSize = true;
-            label20.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label20.ForeColor = Color.FromArgb(64, 64, 64);
-            label20.Location = new Point(18, 84);
-            label20.Name = "label20";
-            label20.Size = new Size(140, 16);
-            label20.TabIndex = 1;
-            label20.Text = "ConnectionPassword";
+            ConnectionPasswordLabel.Anchor = AnchorStyles.Left;
+            ConnectionPasswordLabel.AutoSize = true;
+            ConnectionPasswordLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConnectionPasswordLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConnectionPasswordLabel.Location = new Point(18, 84);
+            ConnectionPasswordLabel.Name = "ConnectionPasswordLabel";
+            ConnectionPasswordLabel.Size = new Size(140, 16);
+            ConnectionPasswordLabel.TabIndex = 1;
+            ConnectionPasswordLabel.Text = "ConnectionPassword";
             // 
-            // label21
+            // ConnectionDomainAddressLabel
             // 
-            label21.Anchor = AnchorStyles.Left;
-            label21.AutoSize = true;
-            label21.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label21.ForeColor = Color.FromArgb(64, 64, 64);
-            label21.Location = new Point(18, 115);
-            label21.Name = "label21";
-            label21.Size = new Size(178, 16);
-            label21.TabIndex = 1;
-            label21.Text = "ConnectionDomainAddress";
+            ConnectionDomainAddressLabel.Anchor = AnchorStyles.Left;
+            ConnectionDomainAddressLabel.AutoSize = true;
+            ConnectionDomainAddressLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConnectionDomainAddressLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConnectionDomainAddressLabel.Location = new Point(18, 115);
+            ConnectionDomainAddressLabel.Name = "ConnectionDomainAddressLabel";
+            ConnectionDomainAddressLabel.Size = new Size(178, 16);
+            ConnectionDomainAddressLabel.TabIndex = 1;
+            ConnectionDomainAddressLabel.Text = "ConnectionDomainAddress";
             // 
-            // textBox15
+            // StationIdSettingTextBox
             // 
-            textBox15.Anchor = AnchorStyles.None;
-            textBox15.Location = new Point(234, 19);
-            textBox15.Name = "textBox15";
-            textBox15.PlaceholderText = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
-            textBox15.Size = new Size(288, 23);
-            textBox15.TabIndex = 2;
+            StationIdSettingTextBox.Anchor = AnchorStyles.None;
+            StationIdSettingTextBox.Location = new Point(234, 19);
+            StationIdSettingTextBox.Name = "StationIdSettingTextBox";
+            StationIdSettingTextBox.PlaceholderText = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
+            StationIdSettingTextBox.Size = new Size(288, 23);
+            StationIdSettingTextBox.TabIndex = 2;
             // 
-            // textBox16
+            // ConnectionPasswordTextBox
             // 
-            textBox16.Anchor = AnchorStyles.None;
-            textBox16.Location = new Point(234, 81);
-            textBox16.Name = "textBox16";
-            textBox16.PlaceholderText = "Kabin Yazılımı Kullanıcı Şifresi";
-            textBox16.Size = new Size(288, 23);
-            textBox16.TabIndex = 2;
+            ConnectionPasswordTextBox.Anchor = AnchorStyles.None;
+            ConnectionPasswordTextBox.Location = new Point(234, 81);
+            ConnectionPasswordTextBox.Name = "ConnectionPasswordTextBox";
+            ConnectionPasswordTextBox.PlaceholderText = "Kabin Yazılımı Kullanıcı Şifresi";
+            ConnectionPasswordTextBox.Size = new Size(288, 23);
+            ConnectionPasswordTextBox.TabIndex = 2;
             // 
-            // textBox17
+            // ConnectionDomainAddressTextBox
             // 
-            textBox17.Anchor = AnchorStyles.None;
-            textBox17.Location = new Point(234, 112);
-            textBox17.Name = "textBox17";
-            textBox17.PlaceholderText = "Kabin Yazılımı Erişim Host veya IP Numarası";
-            textBox17.Size = new Size(288, 23);
-            textBox17.TabIndex = 2;
+            ConnectionDomainAddressTextBox.Anchor = AnchorStyles.None;
+            ConnectionDomainAddressTextBox.Location = new Point(234, 112);
+            ConnectionDomainAddressTextBox.Name = "ConnectionDomainAddressTextBox";
+            ConnectionDomainAddressTextBox.PlaceholderText = "Kabin Yazılımı Erişim Host veya IP Numarası";
+            ConnectionDomainAddressTextBox.Size = new Size(288, 23);
+            ConnectionDomainAddressTextBox.TabIndex = 2;
             // 
-            // textBox20
+            // ConnectionUserTextBox
             // 
-            textBox20.Anchor = AnchorStyles.None;
-            textBox20.Location = new Point(234, 50);
-            textBox20.Name = "textBox20";
-            textBox20.PlaceholderText = "Kabin Yazılımı Kullanıcı Adı";
-            textBox20.Size = new Size(288, 23);
-            textBox20.TabIndex = 2;
+            ConnectionUserTextBox.Anchor = AnchorStyles.None;
+            ConnectionUserTextBox.Location = new Point(234, 50);
+            ConnectionUserTextBox.Name = "ConnectionUserTextBox";
+            ConnectionUserTextBox.PlaceholderText = "Kabin Yazılımı Kullanıcı Adı";
+            ConnectionUserTextBox.Size = new Size(288, 23);
+            ConnectionUserTextBox.TabIndex = 2;
             // 
-            // label22
+            // ConnectionPortLabel
             // 
-            label22.Anchor = AnchorStyles.Left;
-            label22.AutoSize = true;
-            label22.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label22.ForeColor = Color.FromArgb(64, 64, 64);
-            label22.Location = new Point(18, 146);
-            label22.Name = "label22";
-            label22.Size = new Size(105, 16);
-            label22.TabIndex = 1;
-            label22.Text = "ConnectionPort";
+            ConnectionPortLabel.Anchor = AnchorStyles.Left;
+            ConnectionPortLabel.AutoSize = true;
+            ConnectionPortLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            ConnectionPortLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            ConnectionPortLabel.Location = new Point(18, 146);
+            ConnectionPortLabel.Name = "ConnectionPortLabel";
+            ConnectionPortLabel.Size = new Size(105, 16);
+            ConnectionPortLabel.TabIndex = 1;
+            ConnectionPortLabel.Text = "ConnectionPort";
             // 
-            // textBox18
+            // ConnectionPortTextBox
             // 
-            textBox18.Anchor = AnchorStyles.None;
-            textBox18.Location = new Point(234, 143);
-            textBox18.Name = "textBox18";
-            textBox18.PlaceholderText = "Kabin Yazılımı Erişim için kullanılan PORT bilgisi";
-            textBox18.Size = new Size(288, 23);
-            textBox18.TabIndex = 2;
+            ConnectionPortTextBox.Anchor = AnchorStyles.None;
+            ConnectionPortTextBox.Location = new Point(234, 143);
+            ConnectionPortTextBox.Name = "ConnectionPortTextBox";
+            ConnectionPortTextBox.PlaceholderText = "Kabin Yazılımı Erişim için kullanılan PORT bilgisi";
+            ConnectionPortTextBox.Size = new Size(288, 23);
+            ConnectionPortTextBox.TabIndex = 2;
             // 
-            // tableLayoutPanel5
+            // StationSettingsHeaderTableLayoutPanel
             // 
-            tableLayoutPanel5.ColumnCount = 2;
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Controls.Add(label2, 0, 0);
-            tableLayoutPanel5.Controls.Add(SaveButton, 1, 0);
-            tableLayoutPanel5.Dock = DockStyle.Fill;
-            tableLayoutPanel5.Location = new Point(547, 0);
-            tableLayoutPanel5.Margin = new Padding(0);
-            tableLayoutPanel5.Name = "tableLayoutPanel5";
-            tableLayoutPanel5.RowCount = 1;
-            tableLayoutPanel5.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel5.Size = new Size(547, 40);
-            tableLayoutPanel5.TabIndex = 4;
+            StationSettingsHeaderTableLayoutPanel.ColumnCount = 2;
+            StationSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            StationSettingsHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            StationSettingsHeaderTableLayoutPanel.Controls.Add(StationSettingsLabel, 0, 0);
+            StationSettingsHeaderTableLayoutPanel.Controls.Add(SaveStationSettingsButton, 1, 0);
+            StationSettingsHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            StationSettingsHeaderTableLayoutPanel.Location = new Point(547, 0);
+            StationSettingsHeaderTableLayoutPanel.Margin = new Padding(0);
+            StationSettingsHeaderTableLayoutPanel.Name = "StationSettingsHeaderTableLayoutPanel";
+            StationSettingsHeaderTableLayoutPanel.RowCount = 1;
+            StationSettingsHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            StationSettingsHeaderTableLayoutPanel.Size = new Size(547, 40);
+            StationSettingsHeaderTableLayoutPanel.TabIndex = 4;
             // 
-            // label2
+            // StationSettingsLabel
             // 
-            label2.AutoSize = true;
-            label2.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label2.ForeColor = Color.FromArgb(64, 64, 64);
-            label2.Location = new Point(3, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(164, 22);
-            label2.TabIndex = 0;
-            label2.Text = "İstasyon Ayarları";
+            StationSettingsLabel.AutoSize = true;
+            StationSettingsLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationSettingsLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationSettingsLabel.Location = new Point(3, 0);
+            StationSettingsLabel.Name = "StationSettingsLabel";
+            StationSettingsLabel.Size = new Size(164, 22);
+            StationSettingsLabel.TabIndex = 0;
+            StationSettingsLabel.Text = "İstasyon Ayarları";
             // 
-            // SaveButton
+            // SaveStationSettingsButton
             // 
-            SaveButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            SaveButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            SaveButton.Location = new Point(452, 3);
-            SaveButton.Name = "SaveButton";
-            SaveButton.Size = new Size(92, 32);
-            SaveButton.TabIndex = 2;
-            SaveButton.Text = "Kaydet";
-            SaveButton.UseVisualStyleBackColor = true;
+            SaveStationSettingsButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            SaveStationSettingsButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SaveStationSettingsButton.Location = new Point(452, 3);
+            SaveStationSettingsButton.Name = "SaveStationSettingsButton";
+            SaveStationSettingsButton.Size = new Size(92, 32);
+            SaveStationSettingsButton.TabIndex = 2;
+            SaveStationSettingsButton.Text = "Kaydet";
+            SaveStationSettingsButton.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel4
+            // StationInfoHeaderTableLayoutPanel
             // 
-            tableLayoutPanel4.ColumnCount = 2;
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Controls.Add(label1, 0, 0);
-            tableLayoutPanel4.Controls.Add(FetchButton, 1, 0);
-            tableLayoutPanel4.Dock = DockStyle.Fill;
-            tableLayoutPanel4.Location = new Point(0, 0);
-            tableLayoutPanel4.Margin = new Padding(0);
-            tableLayoutPanel4.Name = "tableLayoutPanel4";
-            tableLayoutPanel4.RowCount = 1;
-            tableLayoutPanel4.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-            tableLayoutPanel4.Size = new Size(547, 40);
-            tableLayoutPanel4.TabIndex = 3;
+            StationInfoHeaderTableLayoutPanel.ColumnCount = 2;
+            StationInfoHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            StationInfoHeaderTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            StationInfoHeaderTableLayoutPanel.Controls.Add(StationInfoLabel, 0, 0);
+            StationInfoHeaderTableLayoutPanel.Controls.Add(FetchStationButton, 1, 0);
+            StationInfoHeaderTableLayoutPanel.Dock = DockStyle.Fill;
+            StationInfoHeaderTableLayoutPanel.Location = new Point(0, 0);
+            StationInfoHeaderTableLayoutPanel.Margin = new Padding(0);
+            StationInfoHeaderTableLayoutPanel.Name = "StationInfoHeaderTableLayoutPanel";
+            StationInfoHeaderTableLayoutPanel.RowCount = 1;
+            StationInfoHeaderTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            StationInfoHeaderTableLayoutPanel.Size = new Size(547, 40);
+            StationInfoHeaderTableLayoutPanel.TabIndex = 3;
             // 
-            // label1
+            // StationInfoLabel
             // 
-            label1.AutoSize = true;
-            label1.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label1.ForeColor = Color.FromArgb(64, 64, 64);
-            label1.Location = new Point(3, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(164, 22);
-            label1.TabIndex = 0;
-            label1.Text = "İstasyon Bilgileri";
+            StationInfoLabel.AutoSize = true;
+            StationInfoLabel.Font = new Font("Arial", 14.25F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationInfoLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationInfoLabel.Location = new Point(3, 0);
+            StationInfoLabel.Name = "StationInfoLabel";
+            StationInfoLabel.Size = new Size(164, 22);
+            StationInfoLabel.TabIndex = 0;
+            StationInfoLabel.Text = "İstasyon Bilgileri";
             // 
-            // FetchButton
+            // FetchStationButton
             // 
-            FetchButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            FetchButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            FetchButton.Location = new Point(452, 3);
-            FetchButton.Name = "FetchButton";
-            FetchButton.Size = new Size(92, 32);
-            FetchButton.TabIndex = 2;
-            FetchButton.Text = "Getir";
-            FetchButton.UseVisualStyleBackColor = true;
+            FetchStationButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            FetchStationButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            FetchStationButton.Location = new Point(452, 3);
+            FetchStationButton.Name = "FetchStationButton";
+            FetchStationButton.Size = new Size(92, 32);
+            FetchStationButton.TabIndex = 2;
+            FetchStationButton.Text = "Getir";
+            FetchStationButton.UseVisualStyleBackColor = true;
             // 
             // StationInfoBgTableLayoutPanel
             // 
@@ -346,34 +346,34 @@
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 42.35294F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 57.6470566F));
             StationInfoContentTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 20F));
-            StationInfoContentTableLayoutPanel.Controls.Add(label4, 0, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(label5, 0, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(label6, 0, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(label7, 0, 3);
-            StationInfoContentTableLayoutPanel.Controls.Add(label8, 0, 4);
-            StationInfoContentTableLayoutPanel.Controls.Add(label9, 0, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(label10, 0, 6);
-            StationInfoContentTableLayoutPanel.Controls.Add(label11, 0, 7);
-            StationInfoContentTableLayoutPanel.Controls.Add(label12, 0, 8);
-            StationInfoContentTableLayoutPanel.Controls.Add(label13, 0, 9);
-            StationInfoContentTableLayoutPanel.Controls.Add(label14, 0, 10);
-            StationInfoContentTableLayoutPanel.Controls.Add(label15, 0, 11);
-            StationInfoContentTableLayoutPanel.Controls.Add(label16, 0, 12);
-            StationInfoContentTableLayoutPanel.Controls.Add(label17, 0, 13);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox1, 1, 0);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox5, 1, 2);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox2, 1, 3);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox6, 1, 4);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox7, 1, 5);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox8, 1, 1);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox3, 1, 6);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox4, 1, 7);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox9, 1, 8);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox10, 1, 9);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox11, 1, 10);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox12, 1, 11);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox13, 1, 12);
-            StationInfoContentTableLayoutPanel.Controls.Add(textBox14, 1, 13);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationIdLabel, 0, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(CodeLabel, 0, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationNameLabel, 0, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(DataPeriodLabel, 0, 3);
+            StationInfoContentTableLayoutPanel.Controls.Add(LastDataDateLabel, 0, 4);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwareAddressLabel, 0, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwarePortLabel, 0, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwareUsernameLabel, 0, 7);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwarePasswordLabel, 0, 8);
+            StationInfoContentTableLayoutPanel.Controls.Add(OrganizationLabel, 0, 9);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationSetupDateLabel, 0, 10);
+            StationInfoContentTableLayoutPanel.Controls.Add(SoftwareSetupDateLabel, 0, 11);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationAddressLabel, 0, 12);
+            StationInfoContentTableLayoutPanel.Controls.Add(SoftwareLabel, 0, 13);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationIdTextBox, 1, 0);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationNameTextBox, 1, 2);
+            StationInfoContentTableLayoutPanel.Controls.Add(DataPeriodTextBox, 1, 3);
+            StationInfoContentTableLayoutPanel.Controls.Add(LastDataDateTextBox, 1, 4);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwareAddressTextBox, 1, 5);
+            StationInfoContentTableLayoutPanel.Controls.Add(CodeTextBox, 1, 1);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwarePortTextBox, 1, 6);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwareUsernameTextBox, 1, 7);
+            StationInfoContentTableLayoutPanel.Controls.Add(CabinSoftwarePasswordTextBox, 1, 8);
+            StationInfoContentTableLayoutPanel.Controls.Add(OrganizationTextBox, 1, 9);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationSetupDateTextBox, 1, 10);
+            StationInfoContentTableLayoutPanel.Controls.Add(SoftwareSetupDateTextBox, 1, 11);
+            StationInfoContentTableLayoutPanel.Controls.Add(StationAddressTextBox, 1, 12);
+            StationInfoContentTableLayoutPanel.Controls.Add(SoftwareTextBox, 1, 13);
             StationInfoContentTableLayoutPanel.Dock = DockStyle.Fill;
             StationInfoContentTableLayoutPanel.Location = new Point(1, 1);
             StationInfoContentTableLayoutPanel.Margin = new Padding(1);
@@ -398,327 +398,327 @@
             StationInfoContentTableLayoutPanel.Size = new Size(540, 461);
             StationInfoContentTableLayoutPanel.TabIndex = 2;
             // 
-            // label4
+            // StationIdLabel
             // 
-            label4.Anchor = AnchorStyles.Left;
-            label4.AutoSize = true;
-            label4.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label4.ForeColor = Color.FromArgb(64, 64, 64);
-            label4.Location = new Point(18, 22);
-            label4.Name = "label4";
-            label4.Size = new Size(75, 16);
-            label4.TabIndex = 1;
-            label4.Text = "İstasyon ID";
+            StationIdLabel.Anchor = AnchorStyles.Left;
+            StationIdLabel.AutoSize = true;
+            StationIdLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationIdLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationIdLabel.Location = new Point(18, 22);
+            StationIdLabel.Name = "StationIdLabel";
+            StationIdLabel.Size = new Size(75, 16);
+            StationIdLabel.TabIndex = 1;
+            StationIdLabel.Text = "İstasyon ID";
             // 
-            // label5
+            // CodeLabel
             // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label5.ForeColor = Color.FromArgb(64, 64, 64);
-            label5.Location = new Point(18, 53);
-            label5.Name = "label5";
-            label5.Size = new Size(40, 16);
-            label5.TabIndex = 1;
-            label5.Text = "Code";
+            CodeLabel.Anchor = AnchorStyles.Left;
+            CodeLabel.AutoSize = true;
+            CodeLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CodeLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CodeLabel.Location = new Point(18, 53);
+            CodeLabel.Name = "CodeLabel";
+            CodeLabel.Size = new Size(40, 16);
+            CodeLabel.TabIndex = 1;
+            CodeLabel.Text = "Code";
             // 
-            // label6
+            // StationNameLabel
             // 
-            label6.Anchor = AnchorStyles.Left;
-            label6.AutoSize = true;
-            label6.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label6.ForeColor = Color.FromArgb(64, 64, 64);
-            label6.Location = new Point(18, 84);
-            label6.Name = "label6";
-            label6.Size = new Size(83, 16);
-            label6.TabIndex = 1;
-            label6.Text = "İstasyon Adı";
+            StationNameLabel.Anchor = AnchorStyles.Left;
+            StationNameLabel.AutoSize = true;
+            StationNameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationNameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationNameLabel.Location = new Point(18, 84);
+            StationNameLabel.Name = "StationNameLabel";
+            StationNameLabel.Size = new Size(83, 16);
+            StationNameLabel.TabIndex = 1;
+            StationNameLabel.Text = "İstasyon Adı";
             // 
-            // label7
+            // DataPeriodLabel
             // 
-            label7.Anchor = AnchorStyles.Left;
-            label7.AutoSize = true;
-            label7.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label7.ForeColor = Color.FromArgb(64, 64, 64);
-            label7.Location = new Point(18, 115);
-            label7.Name = "label7";
-            label7.Size = new Size(97, 16);
-            label7.TabIndex = 1;
-            label7.Text = "Veri Periyodu ";
+            DataPeriodLabel.Anchor = AnchorStyles.Left;
+            DataPeriodLabel.AutoSize = true;
+            DataPeriodLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            DataPeriodLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            DataPeriodLabel.Location = new Point(18, 115);
+            DataPeriodLabel.Name = "DataPeriodLabel";
+            DataPeriodLabel.Size = new Size(97, 16);
+            DataPeriodLabel.TabIndex = 1;
+            DataPeriodLabel.Text = "Veri Periyodu ";
             // 
-            // label8
+            // LastDataDateLabel
             // 
-            label8.Anchor = AnchorStyles.Left;
-            label8.AutoSize = true;
-            label8.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label8.ForeColor = Color.FromArgb(64, 64, 64);
-            label8.Location = new Point(18, 146);
-            label8.Name = "label8";
-            label8.Size = new Size(101, 16);
-            label8.TabIndex = 1;
-            label8.Text = "Son Veri Tarihi";
+            LastDataDateLabel.Anchor = AnchorStyles.Left;
+            LastDataDateLabel.AutoSize = true;
+            LastDataDateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            LastDataDateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            LastDataDateLabel.Location = new Point(18, 146);
+            LastDataDateLabel.Name = "LastDataDateLabel";
+            LastDataDateLabel.Size = new Size(101, 16);
+            LastDataDateLabel.TabIndex = 1;
+            LastDataDateLabel.Text = "Son Veri Tarihi";
             // 
-            // label9
+            // CabinSoftwareAddressLabel
             // 
-            label9.Anchor = AnchorStyles.Left;
-            label9.AutoSize = true;
-            label9.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label9.ForeColor = Color.FromArgb(64, 64, 64);
-            label9.Location = new Point(18, 177);
-            label9.Name = "label9";
-            label9.Size = new Size(199, 16);
-            label9.TabIndex = 1;
-            label9.Text = "Kabin Yazılımı Bağlantı Adresi";
+            CabinSoftwareAddressLabel.Anchor = AnchorStyles.Left;
+            CabinSoftwareAddressLabel.AutoSize = true;
+            CabinSoftwareAddressLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CabinSoftwareAddressLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CabinSoftwareAddressLabel.Location = new Point(18, 177);
+            CabinSoftwareAddressLabel.Name = "CabinSoftwareAddressLabel";
+            CabinSoftwareAddressLabel.Size = new Size(199, 16);
+            CabinSoftwareAddressLabel.TabIndex = 1;
+            CabinSoftwareAddressLabel.Text = "Kabin Yazılımı Bağlantı Adresi";
             // 
-            // label10
+            // CabinSoftwarePortLabel
             // 
-            label10.Anchor = AnchorStyles.Left;
-            label10.AutoSize = true;
-            label10.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label10.ForeColor = Color.FromArgb(64, 64, 64);
-            label10.Location = new Point(18, 208);
-            label10.Name = "label10";
-            label10.Size = new Size(193, 16);
-            label10.TabIndex = 1;
-            label10.Text = "Kabin Yazılımı Bağlantı Portu";
+            CabinSoftwarePortLabel.Anchor = AnchorStyles.Left;
+            CabinSoftwarePortLabel.AutoSize = true;
+            CabinSoftwarePortLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CabinSoftwarePortLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CabinSoftwarePortLabel.Location = new Point(18, 208);
+            CabinSoftwarePortLabel.Name = "CabinSoftwarePortLabel";
+            CabinSoftwarePortLabel.Size = new Size(193, 16);
+            CabinSoftwarePortLabel.TabIndex = 1;
+            CabinSoftwarePortLabel.Text = "Kabin Yazılımı Bağlantı Portu";
             // 
-            // label11
+            // CabinSoftwareUsernameLabel
             // 
-            label11.Anchor = AnchorStyles.Left;
-            label11.AutoSize = true;
-            label11.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label11.ForeColor = Color.FromArgb(64, 64, 64);
-            label11.Location = new Point(18, 239);
-            label11.Name = "label11";
-            label11.Size = new Size(183, 16);
-            label11.TabIndex = 1;
-            label11.Text = "Kabin Yazılımı Kullanıcı Adı";
+            CabinSoftwareUsernameLabel.Anchor = AnchorStyles.Left;
+            CabinSoftwareUsernameLabel.AutoSize = true;
+            CabinSoftwareUsernameLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CabinSoftwareUsernameLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CabinSoftwareUsernameLabel.Location = new Point(18, 239);
+            CabinSoftwareUsernameLabel.Name = "CabinSoftwareUsernameLabel";
+            CabinSoftwareUsernameLabel.Size = new Size(183, 16);
+            CabinSoftwareUsernameLabel.TabIndex = 1;
+            CabinSoftwareUsernameLabel.Text = "Kabin Yazılımı Kullanıcı Adı";
             // 
-            // label12
+            // CabinSoftwarePasswordLabel
             // 
-            label12.Anchor = AnchorStyles.Left;
-            label12.AutoSize = true;
-            label12.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label12.ForeColor = Color.FromArgb(64, 64, 64);
-            label12.Location = new Point(18, 270);
-            label12.Name = "label12";
-            label12.Size = new Size(202, 16);
-            label12.TabIndex = 1;
-            label12.Text = "Kabin Yazılımı Kullanıcı Şifresi";
+            CabinSoftwarePasswordLabel.Anchor = AnchorStyles.Left;
+            CabinSoftwarePasswordLabel.AutoSize = true;
+            CabinSoftwarePasswordLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            CabinSoftwarePasswordLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            CabinSoftwarePasswordLabel.Location = new Point(18, 270);
+            CabinSoftwarePasswordLabel.Name = "CabinSoftwarePasswordLabel";
+            CabinSoftwarePasswordLabel.Size = new Size(202, 16);
+            CabinSoftwarePasswordLabel.TabIndex = 1;
+            CabinSoftwarePasswordLabel.Text = "Kabin Yazılımı Kullanıcı Şifresi";
             // 
-            // label13
+            // OrganizationLabel
             // 
-            label13.Anchor = AnchorStyles.Left;
-            label13.AutoSize = true;
-            label13.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label13.ForeColor = Color.FromArgb(64, 64, 64);
-            label13.Location = new Point(18, 301);
-            label13.Name = "label13";
-            label13.Size = new Size(49, 16);
-            label13.TabIndex = 1;
-            label13.Text = "Kurum";
+            OrganizationLabel.Anchor = AnchorStyles.Left;
+            OrganizationLabel.AutoSize = true;
+            OrganizationLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            OrganizationLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            OrganizationLabel.Location = new Point(18, 301);
+            OrganizationLabel.Name = "OrganizationLabel";
+            OrganizationLabel.Size = new Size(49, 16);
+            OrganizationLabel.TabIndex = 1;
+            OrganizationLabel.Text = "Kurum";
             // 
-            // label14
+            // StationSetupDateLabel
             // 
-            label14.Anchor = AnchorStyles.Left;
-            label14.AutoSize = true;
-            label14.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label14.ForeColor = Color.FromArgb(64, 64, 64);
-            label14.Location = new Point(18, 332);
-            label14.Name = "label14";
-            label14.Size = new Size(156, 16);
-            label14.TabIndex = 1;
-            label14.Text = "İstasyon Kurulum Tarihi";
+            StationSetupDateLabel.Anchor = AnchorStyles.Left;
+            StationSetupDateLabel.AutoSize = true;
+            StationSetupDateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationSetupDateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationSetupDateLabel.Location = new Point(18, 332);
+            StationSetupDateLabel.Name = "StationSetupDateLabel";
+            StationSetupDateLabel.Size = new Size(156, 16);
+            StationSetupDateLabel.TabIndex = 1;
+            StationSetupDateLabel.Text = "İstasyon Kurulum Tarihi";
             // 
-            // label15
+            // SoftwareSetupDateLabel
             // 
-            label15.Anchor = AnchorStyles.Left;
-            label15.AutoSize = true;
-            label15.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label15.ForeColor = Color.FromArgb(64, 64, 64);
-            label15.Location = new Point(18, 363);
-            label15.Name = "label15";
-            label15.Size = new Size(151, 16);
-            label15.TabIndex = 1;
-            label15.Text = "Yazılım Kurulum Tarihi";
+            SoftwareSetupDateLabel.Anchor = AnchorStyles.Left;
+            SoftwareSetupDateLabel.AutoSize = true;
+            SoftwareSetupDateLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            SoftwareSetupDateLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            SoftwareSetupDateLabel.Location = new Point(18, 363);
+            SoftwareSetupDateLabel.Name = "SoftwareSetupDateLabel";
+            SoftwareSetupDateLabel.Size = new Size(151, 16);
+            SoftwareSetupDateLabel.TabIndex = 1;
+            SoftwareSetupDateLabel.Text = "Yazılım Kurulum Tarihi";
             // 
-            // label16
+            // StationAddressLabel
             // 
-            label16.Anchor = AnchorStyles.Left;
-            label16.AutoSize = true;
-            label16.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label16.ForeColor = Color.FromArgb(64, 64, 64);
-            label16.Location = new Point(18, 394);
-            label16.Name = "label16";
-            label16.Size = new Size(102, 16);
-            label16.TabIndex = 1;
-            label16.Text = "İstasyon Adresi";
+            StationAddressLabel.Anchor = AnchorStyles.Left;
+            StationAddressLabel.AutoSize = true;
+            StationAddressLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            StationAddressLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            StationAddressLabel.Location = new Point(18, 394);
+            StationAddressLabel.Name = "StationAddressLabel";
+            StationAddressLabel.Size = new Size(102, 16);
+            StationAddressLabel.TabIndex = 1;
+            StationAddressLabel.Text = "İstasyon Adresi";
             // 
-            // label17
+            // SoftwareLabel
             // 
-            label17.Anchor = AnchorStyles.Left;
-            label17.AutoSize = true;
-            label17.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
-            label17.ForeColor = Color.FromArgb(64, 64, 64);
-            label17.Location = new Point(18, 425);
-            label17.Name = "label17";
-            label17.Size = new Size(53, 16);
-            label17.TabIndex = 1;
-            label17.Text = "Yazılım";
+            SoftwareLabel.Anchor = AnchorStyles.Left;
+            SoftwareLabel.AutoSize = true;
+            SoftwareLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            SoftwareLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            SoftwareLabel.Location = new Point(18, 425);
+            SoftwareLabel.Name = "SoftwareLabel";
+            SoftwareLabel.Size = new Size(53, 16);
+            SoftwareLabel.TabIndex = 1;
+            SoftwareLabel.Text = "Yazılım";
             // 
-            // textBox1
+            // StationIdTextBox
             // 
-            textBox1.Anchor = AnchorStyles.None;
-            textBox1.Enabled = false;
-            textBox1.Location = new Point(235, 19);
-            textBox1.Name = "textBox1";
-            textBox1.PlaceholderText = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
-            textBox1.Size = new Size(285, 23);
-            textBox1.TabIndex = 2;
-            textBox1.TextChanged += textBox1_TextChanged;
+            StationIdTextBox.Anchor = AnchorStyles.None;
+            StationIdTextBox.Enabled = false;
+            StationIdTextBox.Location = new Point(235, 19);
+            StationIdTextBox.Name = "StationIdTextBox";
+            StationIdTextBox.PlaceholderText = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
+            StationIdTextBox.Size = new Size(285, 23);
+            StationIdTextBox.TabIndex = 2;
+            StationIdTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox5
+            // StationNameTextBox
             // 
-            textBox5.Anchor = AnchorStyles.None;
-            textBox5.Enabled = false;
-            textBox5.Location = new Point(235, 81);
-            textBox5.Name = "textBox5";
-            textBox5.PlaceholderText = "Test Sais İstasyonu";
-            textBox5.Size = new Size(285, 23);
-            textBox5.TabIndex = 2;
-            textBox5.TextChanged += textBox1_TextChanged;
+            StationNameTextBox.Anchor = AnchorStyles.None;
+            StationNameTextBox.Enabled = false;
+            StationNameTextBox.Location = new Point(235, 81);
+            StationNameTextBox.Name = "StationNameTextBox";
+            StationNameTextBox.PlaceholderText = "Test Sais İstasyonu";
+            StationNameTextBox.Size = new Size(285, 23);
+            StationNameTextBox.TabIndex = 2;
+            StationNameTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox2
+            // DataPeriodTextBox
             // 
-            textBox2.Anchor = AnchorStyles.None;
-            textBox2.Enabled = false;
-            textBox2.Location = new Point(235, 112);
-            textBox2.Name = "textBox2";
-            textBox2.PlaceholderText = "1";
-            textBox2.Size = new Size(285, 23);
-            textBox2.TabIndex = 2;
-            textBox2.TextChanged += textBox1_TextChanged;
+            DataPeriodTextBox.Anchor = AnchorStyles.None;
+            DataPeriodTextBox.Enabled = false;
+            DataPeriodTextBox.Location = new Point(235, 112);
+            DataPeriodTextBox.Name = "DataPeriodTextBox";
+            DataPeriodTextBox.PlaceholderText = "1";
+            DataPeriodTextBox.Size = new Size(285, 23);
+            DataPeriodTextBox.TabIndex = 2;
+            DataPeriodTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox6
+            // LastDataDateTextBox
             // 
-            textBox6.Anchor = AnchorStyles.None;
-            textBox6.Enabled = false;
-            textBox6.Location = new Point(235, 143);
-            textBox6.Name = "textBox6";
-            textBox6.PlaceholderText = "2019-12-01T00:00:00";
-            textBox6.Size = new Size(285, 23);
-            textBox6.TabIndex = 2;
-            textBox6.TextChanged += textBox1_TextChanged;
+            LastDataDateTextBox.Anchor = AnchorStyles.None;
+            LastDataDateTextBox.Enabled = false;
+            LastDataDateTextBox.Location = new Point(235, 143);
+            LastDataDateTextBox.Name = "LastDataDateTextBox";
+            LastDataDateTextBox.PlaceholderText = "2019-12-01T00:00:00";
+            LastDataDateTextBox.Size = new Size(285, 23);
+            LastDataDateTextBox.TabIndex = 2;
+            LastDataDateTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox7
+            // CabinSoftwareAddressTextBox
             // 
-            textBox7.Anchor = AnchorStyles.None;
-            textBox7.Enabled = false;
-            textBox7.Location = new Point(235, 174);
-            textBox7.Name = "textBox7";
-            textBox7.PlaceholderText = "istanbul.ssl";
-            textBox7.Size = new Size(285, 23);
-            textBox7.TabIndex = 2;
-            textBox7.TextChanged += textBox1_TextChanged;
+            CabinSoftwareAddressTextBox.Anchor = AnchorStyles.None;
+            CabinSoftwareAddressTextBox.Enabled = false;
+            CabinSoftwareAddressTextBox.Location = new Point(235, 174);
+            CabinSoftwareAddressTextBox.Name = "CabinSoftwareAddressTextBox";
+            CabinSoftwareAddressTextBox.PlaceholderText = "istanbul.ssl";
+            CabinSoftwareAddressTextBox.Size = new Size(285, 23);
+            CabinSoftwareAddressTextBox.TabIndex = 2;
+            CabinSoftwareAddressTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox8
+            // CodeTextBox
             // 
-            textBox8.Anchor = AnchorStyles.None;
-            textBox8.Enabled = false;
-            textBox8.Location = new Point(235, 50);
-            textBox8.Name = "textBox8";
-            textBox8.PlaceholderText = "0337000";
-            textBox8.Size = new Size(285, 23);
-            textBox8.TabIndex = 2;
-            textBox8.TextChanged += textBox1_TextChanged;
+            CodeTextBox.Anchor = AnchorStyles.None;
+            CodeTextBox.Enabled = false;
+            CodeTextBox.Location = new Point(235, 50);
+            CodeTextBox.Name = "CodeTextBox";
+            CodeTextBox.PlaceholderText = "0337000";
+            CodeTextBox.Size = new Size(285, 23);
+            CodeTextBox.TabIndex = 2;
+            CodeTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox3
+            // CabinSoftwarePortTextBox
             // 
-            textBox3.Anchor = AnchorStyles.None;
-            textBox3.Enabled = false;
-            textBox3.Location = new Point(235, 205);
-            textBox3.Name = "textBox3";
-            textBox3.PlaceholderText = "443";
-            textBox3.Size = new Size(285, 23);
-            textBox3.TabIndex = 2;
-            textBox3.TextChanged += textBox1_TextChanged;
+            CabinSoftwarePortTextBox.Anchor = AnchorStyles.None;
+            CabinSoftwarePortTextBox.Enabled = false;
+            CabinSoftwarePortTextBox.Location = new Point(235, 205);
+            CabinSoftwarePortTextBox.Name = "CabinSoftwarePortTextBox";
+            CabinSoftwarePortTextBox.PlaceholderText = "443";
+            CabinSoftwarePortTextBox.Size = new Size(285, 23);
+            CabinSoftwarePortTextBox.TabIndex = 2;
+            CabinSoftwarePortTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox4
+            // CabinSoftwareUsernameTextBox
             // 
-            textBox4.Anchor = AnchorStyles.None;
-            textBox4.Enabled = false;
-            textBox4.Location = new Point(235, 236);
-            textBox4.Name = "textBox4";
-            textBox4.PlaceholderText = "iski";
-            textBox4.Size = new Size(285, 23);
-            textBox4.TabIndex = 2;
-            textBox4.TextChanged += textBox1_TextChanged;
+            CabinSoftwareUsernameTextBox.Anchor = AnchorStyles.None;
+            CabinSoftwareUsernameTextBox.Enabled = false;
+            CabinSoftwareUsernameTextBox.Location = new Point(235, 236);
+            CabinSoftwareUsernameTextBox.Name = "CabinSoftwareUsernameTextBox";
+            CabinSoftwareUsernameTextBox.PlaceholderText = "iski";
+            CabinSoftwareUsernameTextBox.Size = new Size(285, 23);
+            CabinSoftwareUsernameTextBox.TabIndex = 2;
+            CabinSoftwareUsernameTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox9
+            // CabinSoftwarePasswordTextBox
             // 
-            textBox9.Anchor = AnchorStyles.None;
-            textBox9.Enabled = false;
-            textBox9.Location = new Point(235, 267);
-            textBox9.Name = "textBox9";
-            textBox9.PlaceholderText = "iski123";
-            textBox9.Size = new Size(285, 23);
-            textBox9.TabIndex = 2;
-            textBox9.TextChanged += textBox1_TextChanged;
+            CabinSoftwarePasswordTextBox.Anchor = AnchorStyles.None;
+            CabinSoftwarePasswordTextBox.Enabled = false;
+            CabinSoftwarePasswordTextBox.Location = new Point(235, 267);
+            CabinSoftwarePasswordTextBox.Name = "CabinSoftwarePasswordTextBox";
+            CabinSoftwarePasswordTextBox.PlaceholderText = "iski123";
+            CabinSoftwarePasswordTextBox.Size = new Size(285, 23);
+            CabinSoftwarePasswordTextBox.TabIndex = 2;
+            CabinSoftwarePasswordTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox10
+            // OrganizationTextBox
             // 
-            textBox10.Anchor = AnchorStyles.None;
-            textBox10.Enabled = false;
-            textBox10.Location = new Point(235, 298);
-            textBox10.Name = "textBox10";
-            textBox10.PlaceholderText = "Test Tesisi";
-            textBox10.Size = new Size(285, 23);
-            textBox10.TabIndex = 2;
-            textBox10.TextChanged += textBox1_TextChanged;
+            OrganizationTextBox.Anchor = AnchorStyles.None;
+            OrganizationTextBox.Enabled = false;
+            OrganizationTextBox.Location = new Point(235, 298);
+            OrganizationTextBox.Name = "OrganizationTextBox";
+            OrganizationTextBox.PlaceholderText = "Test Tesisi";
+            OrganizationTextBox.Size = new Size(285, 23);
+            OrganizationTextBox.TabIndex = 2;
+            OrganizationTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox11
+            // StationSetupDateTextBox
             // 
-            textBox11.Anchor = AnchorStyles.None;
-            textBox11.Enabled = false;
-            textBox11.Location = new Point(235, 329);
-            textBox11.Name = "textBox11";
-            textBox11.PlaceholderText = "2019-12-01T00:00:00";
-            textBox11.Size = new Size(285, 23);
-            textBox11.TabIndex = 2;
-            textBox11.TextChanged += textBox1_TextChanged;
+            StationSetupDateTextBox.Anchor = AnchorStyles.None;
+            StationSetupDateTextBox.Enabled = false;
+            StationSetupDateTextBox.Location = new Point(235, 329);
+            StationSetupDateTextBox.Name = "StationSetupDateTextBox";
+            StationSetupDateTextBox.PlaceholderText = "2019-12-01T00:00:00";
+            StationSetupDateTextBox.Size = new Size(285, 23);
+            StationSetupDateTextBox.TabIndex = 2;
+            StationSetupDateTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox12
+            // SoftwareSetupDateTextBox
             // 
-            textBox12.Anchor = AnchorStyles.None;
-            textBox12.Enabled = false;
-            textBox12.Location = new Point(235, 360);
-            textBox12.Name = "textBox12";
-            textBox12.PlaceholderText = "2019-12-01T00:00:00";
-            textBox12.Size = new Size(285, 23);
-            textBox12.TabIndex = 2;
-            textBox12.TextChanged += textBox1_TextChanged;
+            SoftwareSetupDateTextBox.Anchor = AnchorStyles.None;
+            SoftwareSetupDateTextBox.Enabled = false;
+            SoftwareSetupDateTextBox.Location = new Point(235, 360);
+            SoftwareSetupDateTextBox.Name = "SoftwareSetupDateTextBox";
+            SoftwareSetupDateTextBox.PlaceholderText = "2019-12-01T00:00:00";
+            SoftwareSetupDateTextBox.Size = new Size(285, 23);
+            SoftwareSetupDateTextBox.TabIndex = 2;
+            SoftwareSetupDateTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox13
+            // StationAddressTextBox
             // 
-            textBox13.Anchor = AnchorStyles.None;
-            textBox13.Enabled = false;
-            textBox13.Location = new Point(235, 391);
-            textBox13.Name = "textBox13";
-            textBox13.PlaceholderText = "İstanbul";
-            textBox13.Size = new Size(285, 23);
-            textBox13.TabIndex = 2;
-            textBox13.TextChanged += textBox1_TextChanged;
+            StationAddressTextBox.Anchor = AnchorStyles.None;
+            StationAddressTextBox.Enabled = false;
+            StationAddressTextBox.Location = new Point(235, 391);
+            StationAddressTextBox.Name = "StationAddressTextBox";
+            StationAddressTextBox.PlaceholderText = "İstanbul";
+            StationAddressTextBox.Size = new Size(285, 23);
+            StationAddressTextBox.TabIndex = 2;
+            StationAddressTextBox.TextChanged += StationInfoTextChanged;
             // 
-            // textBox14
+            // SoftwareTextBox
             // 
-            textBox14.Anchor = AnchorStyles.None;
-            textBox14.Enabled = false;
-            textBox14.Location = new Point(235, 422);
-            textBox14.Name = "textBox14";
-            textBox14.PlaceholderText = "IBKS";
-            textBox14.Size = new Size(285, 23);
-            textBox14.TabIndex = 2;
-            textBox14.TextChanged += textBox1_TextChanged;
+            SoftwareTextBox.Anchor = AnchorStyles.None;
+            SoftwareTextBox.Enabled = false;
+            SoftwareTextBox.Location = new Point(235, 422);
+            SoftwareTextBox.Name = "SoftwareTextBox";
+            SoftwareTextBox.PlaceholderText = "IBKS";
+            SoftwareTextBox.Size = new Size(285, 23);
+            SoftwareTextBox.TabIndex = 2;
+            SoftwareTextBox.TextChanged += StationInfoTextChanged;
             // 
             // StationSettingsPage
             // 
@@ -731,10 +731,10 @@
             StationSettingsBgTableLayoutPanel.ResumeLayout(false);
             StationSettingsContentTableLayoutPanel.ResumeLayout(false);
             StationSettingsContentTableLayoutPanel.PerformLayout();
-            tableLayoutPanel5.ResumeLayout(false);
-            tableLayoutPanel5.PerformLayout();
-            tableLayoutPanel4.ResumeLayout(false);
-            tableLayoutPanel4.PerformLayout();
+            StationSettingsHeaderTableLayoutPanel.ResumeLayout(false);
+            StationSettingsHeaderTableLayoutPanel.PerformLayout();
+            StationInfoHeaderTableLayoutPanel.ResumeLayout(false);
+            StationInfoHeaderTableLayoutPanel.PerformLayout();
             StationInfoBgTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.ResumeLayout(false);
             StationInfoContentTableLayoutPanel.PerformLayout();
@@ -744,52 +744,52 @@
         #endregion
 
         private TableLayoutPanel StationSettingsBgTableLayoutPanel;
-        private Label label1;
-        private Button FetchButton;
-        private TableLayoutPanel tableLayoutPanel4;
-        private TableLayoutPanel tableLayoutPanel5;
-        private Label label2;
-        private Button SaveButton;
+        private Label StationInfoLabel;
+        private Button FetchStationButton;
+        private TableLayoutPanel StationInfoHeaderTableLayoutPanel;
+        private TableLayoutPanel StationSettingsHeaderTableLayoutPanel;
+        private Label StationSettingsLabel;
+        private Button SaveStationSettingsButton;
         private TableLayoutPanel StationInfoBgTableLayoutPanel;
         private TableLayoutPanel StationInfoContentTableLayoutPanel;
-        private Label label4;
-        private Label label5;
-        private Label label6;
-        private Label label7;
-        private Label label8;
-        private Label label9;
-        private Label label10;
-        private Label label11;
-        private Label label12;
-        private Label label13;
-        private Label label14;
-        private Label label15;
-        private Label label16;
-        private Label label17;
-        private TextBox textBox1;
-        private TextBox textBox2;
-        private TextBox textBox5;
-        private TextBox textBox6;
-        private TextBox textBox7;
-        private TextBox textBox8;
-        private TextBox textBox3;
-        private TextBox textBox4;
-        private TextBox textBox9;
-        private TextBox textBox10;
-        private TextBox textBox11;
-        private TextBox textBox12;
-        private TextBox textBox13;
-        private TextBox textBox14;
+        private Label StationIdLabel;
+        private Label CodeLabel;
+        private Label StationNameLabel;
+        private Label DataPeriodLabel;
+        private Label LastDataDateLabel;
+        private Label CabinSoftwareAddressLabel;
+        private Label CabinSoftwarePortLabel;
+        private Label CabinSoftwareUsernameLabel;
+        private Label CabinSoftwarePasswordLabel;
+        private Label OrganizationLabel;
+        private Label StationSetupDateLabel;
+        private Label SoftwareSetupDateLabel;
+        private Label StationAddressLabel;
+        private Label SoftwareLabel;
+        private TextBox StationIdTextBox;
+        private TextBox DataPeriodTextBox;
+        private TextBox StationNameTextBox;
+        private TextBox LastDataDateTextBox;
+        private TextBox CabinSoftwareAddressTextBox;
+        private TextBox CodeTextBox;
+        private TextBox CabinSoftwarePortTextBox;
+        private TextBox CabinSoftwareUsernameTextBox;
+        private TextBox CabinSoftwarePasswordTextBox;
+        private TextBox OrganizationTextBox;
+        private TextBox StationSetupDateTextBox;
+        private TextBox SoftwareSetupDateTextBox;
+        private TextBox StationAddressTextBox;
+        private TextBox SoftwareTextBox;
         private TableLayoutPanel StationSettingsContentTableLayoutPanel;
-        private Label label18;
-        private Label label19;
-        private Label label20;
-        private Label label21;
-        private TextBox textBox15;
-        private TextBox textBox16;
-        private TextBox textBox17;
-        private TextBox textBox20;
-        private Label label22;
-        private TextBox textBox18;
+        private Label StationIdSettingLabel;
+        private Label ConnectionUserLabel;
+        private Label ConnectionPasswordLabel;
+        private Label ConnectionDomainAddressLabel;
+        private TextBox StationIdSettingTextBox;
+        private TextBox ConnectionPasswordTextBox;
+        private TextBox ConnectionDomainAddressTextBox;
+        private TextBox ConnectionUserTextBox;
+        private Label ConnectionPortLabel;
+        private TextBox ConnectionPortTextBox;
     }
 }

--- a/WinUI/Pages/Settings/StationSettingsPage.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.cs
@@ -18,7 +18,7 @@ namespace WinUI.Pages.Settings
             InitializeComponent();
         }
 
-        private void textBox1_TextChanged(object sender, EventArgs e)
+        private void StationInfoTextChanged(object sender, EventArgs e)
         {
 
         }


### PR DESCRIPTION
## Summary
- rename API settings controls to descriptive names
- refactor calibration page with explicit control naming
- clarify channel, database, mail user, and station settings control names

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55967901c8324a5310d4510733e05