### PR TITLE
Implement station creation via WinUI and tidy naming

### DIFF
--- a/Application/Features/SendDatas/Dtos/SendDataDto.cs
+++ b/Application/Features/SendDatas/Dtos/SendDataDto.cs
@@ -3,8 +3,8 @@ namespace Application.Features.SendDatas.Dtos;
 public class SendDataDto
 {
     public int Id { get; set; }
-    public Guid Stationid { get; set; }
-    public DateTime Readtime { get; set; }
+    public Guid StationId { get; set; }
+    public DateTime ReadTime { get; set; }
     public string SoftwareVersion { get; set; }
     public double AkisHizi { get; set; }
     public double AKM { get; set; }

--- a/Domain/Entities/SendData.cs
+++ b/Domain/Entities/SendData.cs
@@ -9,8 +9,8 @@ namespace Domain.Entities;
 
 public class SendData : BaseEntity<int>
 {
-    public Guid Stationid { get; set; }
-    public DateTime Readtime { get; set; }
+    public Guid StationId { get; set; }
+    public DateTime ReadTime { get; set; }
     public string SoftwareVersion { get; set; }
     public double AkisHizi { get; set; }
     public double AKM { get; set; }

--- a/WinUI/Models/CreateStationCommand.cs
+++ b/WinUI/Models/CreateStationCommand.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace WinUI.Models;
+
+public record CreateStationCommand(string StationName, Guid StationId);
+

--- a/WinUI/Models/StationDto.cs
+++ b/WinUI/Models/StationDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace WinUI.Models;
+
+public class StationDto
+{
+    public string StationName { get; set; }
+    public Guid StationId { get; set; }
+}
+

--- a/WinUI/Pages/Settings/StationSettingsPage.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.cs
@@ -8,19 +8,42 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using WinUI.Helpers;
+using WinUI.Services;
+using WinUI.Models;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WinUI.Pages.Settings
 {
     public partial class StationSettingsPage : UserControl
     {
+        private readonly IStationService _stationService;
+
         public StationSettingsPage()
         {
             InitializeComponent();
+            _stationService = Program.Services.GetRequiredService<IStationService>();
+            SaveStationSettingsButton.Click += SaveStationSettingsButton_Click;
         }
 
         private void StationInfoTextChanged(object sender, EventArgs e)
         {
 
+        }
+
+        private async void SaveStationSettingsButton_Click(object? sender, EventArgs e)
+        {
+            if (!Guid.TryParse(StationIdTextBox.Text, out var stationId))
+            {
+                MessageBox.Show("Geçersiz istasyon Id", "Hata", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var command = new CreateStationCommand(StationNameTextBox.Text, stationId);
+            var result = await _stationService.CreateAsync(command);
+            if (result != null)
+            {
+                MessageBox.Show($"İstasyon '{result.StationName}' kaydedildi.", "Bilgi", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -10,6 +10,7 @@ namespace WinUI
 {
     internal static class Program
     {
+        internal static IServiceProvider? Services { get; private set; }
         [STAThread]
         static void Main(string[] args)
         {
@@ -24,7 +25,8 @@ namespace WinUI
             splashThread.Start();
 
             var host = CreateHostBuilder(args).Build();
-            using var scope = host.Services.CreateScope();
+            Services = host.Services;
+            using var scope = Services.CreateScope();
             var services = scope.ServiceProvider;
 
             var mainForm = services.GetRequiredService<MainForm>();
@@ -49,16 +51,32 @@ namespace WinUI
                     services.AddHttpClient<IPlcDataService, PlcDataService>(client =>
                     {
                         string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:443";
-
                         baseUrl = baseUrl.TrimEnd('/');
-
                         client.BaseAddress = new Uri(baseUrl);
-
                     })
                     .ConfigurePrimaryHttpMessageHandler(() =>
                     {
                         var handler = new HttpClientHandler();
-                        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        }
+                        return handler;
+                    });
+
+                    services.AddHttpClient<IStationService, StationService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:443";
+                        baseUrl = baseUrl.TrimEnd('/');
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        }
                         return handler;
                     });
                 });

--- a/WinUI/Services/IStationService.cs
+++ b/WinUI/Services/IStationService.cs
@@ -1,0 +1,9 @@
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IStationService
+{
+    Task<StationDto?> CreateAsync(CreateStationCommand command);
+}
+

--- a/WinUI/Services/PlcDataService.cs
+++ b/WinUI/Services/PlcDataService.cs
@@ -12,9 +12,6 @@ public class PlcDataService : IPlcDataService
     public PlcDataService(HttpClient httpClient)
     {
         _httpClient = httpClient;
-
-        HttpClientHandler handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
     }
 
     public async Task<PlcDataDto?> ReadAndSaveAsync()

--- a/WinUI/Services/StationService.cs
+++ b/WinUI/Services/StationService.cs
@@ -1,0 +1,23 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public class StationService : IStationService
+{
+    private readonly HttpClient _httpClient;
+
+    public StationService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<StationDto?> CreateAsync(CreateStationCommand command)
+    {
+        using var response = await _httpClient.PostAsJsonAsync("api/stations", command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<StationDto>();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add StationService and models to allow StationSettingsPage to create stations through the API
- Wire StationSettingsPage save button to post station data via IStationService
- Limit insecure certificate overrides to development and remove unused HttpClientHandler
- Use PascalCase for StationId and ReadTime in SendData domain and DTO

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b67df0323c83248b33e81f39937fad