### PR TITLE
Add database logging for station operations

### DIFF
--- a/Application/Features/Stations/Commands/Create/CreateStationCommandHandler.cs
+++ b/Application/Features/Stations/Commands/Create/CreateStationCommandHandler.cs
@@ -1,6 +1,7 @@
 using Application.Features.Stations.Dtos;
 using AutoMapper;
 using Domain.Entities;
+using Domain.Enums;
 using Infrastructure.Persistence.Abstract;
 using MediatR;
 
@@ -8,12 +9,36 @@ namespace Application.Features.Stations.Commands.Create;
 
 public class CreateStationCommandHandler(
     IStationRepository repository,
+    IAppLogRepository logRepository,
     IMapper mapper) : IRequestHandler<CreateStationCommand, StationDto>
 {
     public async Task<StationDto> Handle(CreateStationCommand request, CancellationToken cancellationToken)
     {
-        var entity = mapper.Map<Station>(request);
-        entity = await repository.AddAsync(entity);
-        return mapper.Map<StationDto>(entity);
+        try
+        {
+            var entity = mapper.Map<Station>(request);
+            entity = await repository.AddAsync(entity);
+
+            await logRepository.AddAsync(new AppLog
+            {
+                Level = LogLevel.Information,
+                Message = $"Station {entity.StationId} created successfully",
+                LoggedAt = DateTime.UtcNow
+            });
+
+            return mapper.Map<StationDto>(entity);
+        }
+        catch (Exception ex)
+        {
+            await logRepository.AddAsync(new AppLog
+            {
+                Level = LogLevel.Error,
+                Message = $"Error creating station {request.StationId}: {ex.Message}",
+                Exception = ex.ToString(),
+                LoggedAt = DateTime.UtcNow
+            });
+
+            throw;
+        }
     }
 }

--- a/Application/Features/Stations/Commands/Update/UpdateStationCommandHandler.cs
+++ b/Application/Features/Stations/Commands/Update/UpdateStationCommandHandler.cs
@@ -1,5 +1,7 @@
 using Application.Features.Stations.Dtos;
 using AutoMapper;
+using Domain.Entities;
+using Domain.Enums;
 using Infrastructure.Persistence.Abstract;
 using MediatR;
 
@@ -7,15 +9,40 @@ namespace Application.Features.Stations.Commands.Update;
 
 public class UpdateStationCommandHandler(
     IStationRepository repository,
+    IAppLogRepository logRepository,
     IMapper mapper) : IRequestHandler<UpdateStationCommand, StationDto>
 {
     public async Task<StationDto> Handle(UpdateStationCommand request, CancellationToken cancellationToken)
     {
-        var entity = await repository.GetByIdAsync(request.Id);
-        if (entity is null)
-            throw new KeyNotFoundException($"Station {request.Id} not found");
-        mapper.Map(request, entity);
-        entity = await repository.UpdateAsync(entity);
-        return mapper.Map<StationDto>(entity);
+        try
+        {
+            var entity = await repository.GetByIdAsync(request.Id);
+            if (entity is null)
+                throw new KeyNotFoundException($"Station {request.Id} not found");
+
+            mapper.Map(request, entity);
+            entity = await repository.UpdateAsync(entity);
+
+            await logRepository.AddAsync(new AppLog
+            {
+                Level = LogLevel.Information,
+                Message = $"Station {entity.StationId} updated successfully",
+                LoggedAt = DateTime.UtcNow
+            });
+
+            return mapper.Map<StationDto>(entity);
+        }
+        catch (Exception ex)
+        {
+            await logRepository.AddAsync(new AppLog
+            {
+                Level = LogLevel.Error,
+                Message = $"Error updating station {request.StationId}: {ex.Message}",
+                Exception = ex.ToString(),
+                LoggedAt = DateTime.UtcNow
+            });
+
+            throw;
+        }
     }
 }

--- a/Domain/Entities/AppLog.cs
+++ b/Domain/Entities/AppLog.cs
@@ -1,0 +1,13 @@
+using System;
+using ISKI.Core.Domain;
+using Domain.Enums;
+
+namespace Domain.Entities;
+
+public class AppLog : BaseEntity<int>
+{
+    public LogLevel Level { get; set; }
+    public string Message { get; set; }
+    public string? Exception { get; set; }
+    public DateTime LoggedAt { get; set; }
+}

--- a/Domain/Enums/LogLevel.cs
+++ b/Domain/Enums/LogLevel.cs
@@ -1,0 +1,7 @@
+namespace Domain.Enums;
+
+public enum LogLevel
+{
+    Information = 0,
+    Error = 1
+}

--- a/Infrastructure/Persistence/Abstract/IAppLogRepository.cs
+++ b/Infrastructure/Persistence/Abstract/IAppLogRepository.cs
@@ -1,0 +1,8 @@
+using Domain.Entities;
+using ISKI.Core.Infrastructure;
+
+namespace Infrastructure.Persistence.Abstract;
+
+public interface IAppLogRepository : IAsyncRepository<AppLog, int>
+{
+}

--- a/Infrastructure/Persistence/IBKSContext.cs
+++ b/Infrastructure/Persistence/IBKSContext.cs
@@ -23,6 +23,7 @@ public class IBKSContext(DbContextOptions<IBKSContext> options) : DbContext(opti
     public DbSet<AnalogSensorData> AnalogSensorData => Set<AnalogSensorData>();
     public DbSet<PlcInformation> PlcInformations => Set<PlcInformation>();
     public DbSet<Station> Stations => Set<Station>();
+    public DbSet<AppLog> AppLogs => Set<AppLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Infrastructure/Persistence/Repositories/AppLogRepository.cs
+++ b/Infrastructure/Persistence/Repositories/AppLogRepository.cs
@@ -1,0 +1,10 @@
+using Domain.Entities;
+using Infrastructure.Persistence.Abstract;
+using ISKI.Core.Infrastructure;
+
+namespace Infrastructure.Persistence.Repositories;
+
+public class AppLogRepository(IBKSContext context)
+    : EfRepositoryBase<AppLog, int, IBKSContext>(context), IAppLogRepository
+{
+}

--- a/Infrastructure/ServiceRegistration.cs
+++ b/Infrastructure/ServiceRegistration.cs
@@ -18,6 +18,7 @@ public static class ServiceRegistration
         services.AddScoped<IMailSettingsRepository, MailSettingsRepository>();
         services.AddScoped<IMailUserRepository, MailUserRepository>();
         services.AddScoped<IMailLogRepository, MailLogRepository>();
+        services.AddScoped<IAppLogRepository, AppLogRepository>();
         services.AddScoped<IMailTriggerRecipientRepository, MailTriggerRecipientRepository>();
         services.AddScoped<ISendDataRepository, SendDataRepository>();
         services.AddScoped<IApiEndpointRepository, ApiEndpointRepository>();


### PR DESCRIPTION
## Summary
- add AppLog entity and repository for database logging
- capture station create/update success or failure in handlers
- register logging repository and context set

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68f735ff883249daf6e09dffe914d