### PR TITLE
Add API settings persistence

### DIFF
--- a/WinUI/Constants/ApiEndpointConstants.cs
+++ b/WinUI/Constants/ApiEndpointConstants.cs
@@ -1,0 +1,9 @@
+namespace WinUI.Constants;
+
+public static class ApiEndpointConstants
+{
+    public const string ApiUrl = "api/apiendpoints";
+    public const string SavedMessage = "API ayarları kaydedildi.";
+    public const string InfoTitle = "Bilgi";
+    public const string ErrorTitle = "Hata";
+}

--- a/WinUI/Models/ApiEndpointDto.cs
+++ b/WinUI/Models/ApiEndpointDto.cs
@@ -1,0 +1,9 @@
+namespace WinUI.Models;
+
+public class ApiEndpointDto
+{
+    public int Id { get; set; }
+    public string ApiAddress { get; set; } = string.Empty;
+    public string UserName { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/WinUI/Pages/Settings/ApiSettingsPage.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.cs
@@ -1,20 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Windows.Forms;
+using WinUI.Constants;
+using WinUI.Services;
 
-namespace WinUI.Pages.Settings
+namespace WinUI.Pages.Settings;
+
+public partial class ApiSettingsPage : UserControl
 {
-    public partial class ApiSettingsPage : UserControl
+    private readonly IApiEndpointService _apiEndpointService;
+    private int? _apiEndpointId;
+
+    public ApiSettingsPage()
     {
-        public ApiSettingsPage()
+        InitializeComponent();
+        _apiEndpointService = Program.Services.GetRequiredService<IApiEndpointService>();
+        Load += ApiSettingsPage_Load;
+        SaveApiSettingsButton.Click += SaveApiSettingsButton_Click;
+    }
+
+    private async void ApiSettingsPage_Load(object? sender, EventArgs e)
+    {
+        var endpoint = await _apiEndpointService.GetFirstAsync();
+        if (endpoint != null)
         {
-            InitializeComponent();
+            _apiEndpointId = endpoint.Id;
+            ApiUrlTextBox.Text = endpoint.ApiAddress;
+            ApiUsernameTextBox.Text = endpoint.UserName;
+            ApiPasswordTextBox.Text = endpoint.Password;
+        }
+    }
+
+    private async void SaveApiSettingsButton_Click(object? sender, EventArgs e)
+    {
+        if (_apiEndpointId.HasValue)
+        {
+            var command = new UpdateApiEndpointCommand(_apiEndpointId.Value, ApiUrlTextBox.Text, ApiUsernameTextBox.Text, ApiPasswordTextBox.Text);
+            var result = await _apiEndpointService.UpdateAsync(_apiEndpointId.Value, command);
+            if (result != null)
+            {
+                MessageBox.Show(ApiEndpointConstants.SavedMessage, ApiEndpointConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+        else
+        {
+            var command = new CreateApiEndpointCommand(ApiUrlTextBox.Text, ApiUsernameTextBox.Text, ApiPasswordTextBox.Text);
+            var result = await _apiEndpointService.CreateAsync(command);
+            if (result != null)
+            {
+                _apiEndpointId = result.Id;
+                MessageBox.Show(ApiEndpointConstants.SavedMessage, ApiEndpointConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -61,21 +61,37 @@ namespace WinUI
                             return handler;
                         });
 
-                    services.AddHttpClient<IStationService, StationService>(client =>
-                    {
-                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
-                        baseUrl = baseUrl.TrimEnd('/');
-                        client.BaseAddress = new Uri(baseUrl);
-                    })
-                    .ConfigurePrimaryHttpMessageHandler(() =>
-                    {
-                        var handler = new HttpClientHandler();
-                        if (context.HostingEnvironment.IsDevelopment())
-                        {
-                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-                        }
-                        return handler;
-                    });
-                });
+                      services.AddHttpClient<IStationService, StationService>(client =>
+                      {
+                          string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                          baseUrl = baseUrl.TrimEnd('/');
+                          client.BaseAddress = new Uri(baseUrl);
+                      })
+                      .ConfigurePrimaryHttpMessageHandler(() =>
+                      {
+                          var handler = new HttpClientHandler();
+                          if (context.HostingEnvironment.IsDevelopment())
+                          {
+                              handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                          }
+                          return handler;
+                      });
+
+                      services.AddHttpClient<IApiEndpointService, ApiEndpointService>(client =>
+                      {
+                          string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                          baseUrl = baseUrl.TrimEnd('/');
+                          client.BaseAddress = new Uri(baseUrl);
+                      })
+                      .ConfigurePrimaryHttpMessageHandler(() =>
+                      {
+                          var handler = new HttpClientHandler();
+                          if (context.HostingEnvironment.IsDevelopment())
+                          {
+                              handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                          }
+                          return handler;
+                      });
+                  });
     }
 }

--- a/WinUI/Services/ApiEndpointService.cs
+++ b/WinUI/Services/ApiEndpointService.cs
@@ -1,0 +1,40 @@
+using System.Net.Http.Json;
+using System.Linq;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public record CreateApiEndpointCommand(string ApiAddress, string UserName, string Password);
+
+public record UpdateApiEndpointCommand(int Id, string ApiAddress, string UserName, string Password);
+
+public interface IApiEndpointService
+{
+    Task<ApiEndpointDto?> GetFirstAsync();
+    Task<ApiEndpointDto?> CreateAsync(CreateApiEndpointCommand command);
+    Task<ApiEndpointDto?> UpdateAsync(int id, UpdateApiEndpointCommand command);
+}
+
+public class ApiEndpointService(HttpClient httpClient) : IApiEndpointService
+{
+    public async Task<ApiEndpointDto?> GetFirstAsync()
+    {
+        var list = await httpClient.GetFromJsonAsync<List<ApiEndpointDto>>(ApiEndpointConstants.ApiUrl);
+        return list?.FirstOrDefault();
+    }
+
+    public async Task<ApiEndpointDto?> CreateAsync(CreateApiEndpointCommand command)
+    {
+        using var response = await httpClient.PostAsJsonAsync(ApiEndpointConstants.ApiUrl, command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ApiEndpointDto>();
+    }
+
+    public async Task<ApiEndpointDto?> UpdateAsync(int id, UpdateApiEndpointCommand command)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{ApiEndpointConstants.ApiUrl}/{id}", command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ApiEndpointDto>();
+    }
+}


### PR DESCRIPTION
## Summary
- add constants, model, and service for API endpoint credentials
- register ApiEndpointService and load/save settings through ApiSettingsPage

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b800eeff408324aa008a03cbed8249