### PR TITLE
Ensure station settings are required before fetching station info

### DIFF
--- a/WinUI/Constants/StationConstants.cs
+++ b/WinUI/Constants/StationConstants.cs
@@ -10,4 +10,6 @@ public static class StationConstants
     public const string StationSavedMessage = "İstasyon '{0}' kaydedildi.";
     public const string InfoTitle = "Bilgi";
     public const string StationIdPlaceholder = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
+    public const string StationSettingsRequiredMessage = "Bu servisi kullanabilmeniz için istasyon ayarlarını tanımlamanız gerekmektedir.";
+    public const string StationInfoApiUrl = "https://enetgrations.csb.gov.tr/SAIS/GetStationInformation";
 }

--- a/WinUI/Pages/Settings/StationSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.Designer.cs
@@ -325,6 +325,7 @@ namespace WinUI.Pages.Settings
             FetchStationButton.TabIndex = 2;
             FetchStationButton.Text = "Getir";
             FetchStationButton.UseVisualStyleBackColor = true;
+            FetchStationButton.Click += FetchStationButton_Click;
             // 
             // StationInfoBgTableLayoutPanel
             // 

--- a/WinUI/Pages/Settings/StationSettingsPage.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using WinUI.Constants;
+using WinUI.Models;
 using WinUI.Services;
 
 namespace WinUI.Pages.Settings;
@@ -9,11 +10,24 @@ namespace WinUI.Pages.Settings;
 public partial class StationSettingsPage : UserControl
 {
     private readonly IStationService _stationService;
+    private readonly IStationInformationService _stationInformationService;
 
     public StationSettingsPage()
     {
         InitializeComponent();
         _stationService = Program.Services.GetRequiredService<IStationService>();
+        _stationInformationService = Program.Services.GetRequiredService<IStationInformationService>();
+    }
+
+    protected override async void OnLoad(EventArgs e)
+    {
+        base.OnLoad(e);
+        var station = await _stationService.GetFirstAsync();
+        if (station != null)
+        {
+            PopulateStationInfo(station);
+            PopulateStationSettings(station);
+        }
     }
 
     private void StationInfoTextChanged(object sender, EventArgs e)
@@ -63,5 +77,48 @@ public partial class StationSettingsPage : UserControl
         {
             MessageBox.Show(string.Format(StationConstants.StationSavedMessage, result.Name), StationConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
+    }
+
+    private async void FetchStationButton_Click(object? sender, EventArgs e)
+    {
+        var station = await _stationService.GetFirstAsync();
+        if (station == null)
+        {
+            MessageBox.Show(StationConstants.StationSettingsRequiredMessage, StationConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        var info = await _stationInformationService.GetAsync(station.StationId);
+        if (info != null)
+        {
+            PopulateStationInfo(info);
+        }
+    }
+
+    private void PopulateStationInfo(StationDto station)
+    {
+        StationIdTextBox.Text = station.StationId.ToString();
+        CodeTextBox.Text = station.Code;
+        StationNameTextBox.Text = station.Name;
+        DataPeriodTextBox.Text = station.DataPeriodMinute.ToString();
+        LastDataDateTextBox.Text = station.LastDataDate.ToString("s");
+        CabinSoftwareAddressTextBox.Text = station.ConnectionDomainAddress;
+        CabinSoftwarePortTextBox.Text = station.ConnectionPort;
+        CabinSoftwareUsernameTextBox.Text = station.ConnectionUser;
+        CabinSoftwarePasswordTextBox.Text = station.ConnectionPassword;
+        OrganizationTextBox.Text = station.Company;
+        StationSetupDateTextBox.Text = station.BirtDate.ToString("d");
+        SoftwareSetupDateTextBox.Text = station.SetupDate.ToString("d");
+        StationAddressTextBox.Text = station.Address;
+        SoftwareTextBox.Text = station.Software;
+    }
+
+    private void PopulateStationSettings(StationDto station)
+    {
+        StationIdSettingTextBox.Text = station.StationId.ToString();
+        ConnectionDomainAddressTextBox.Text = station.ConnectionDomainAddress;
+        ConnectionPortTextBox.Text = station.ConnectionPort;
+        ConnectionUserTextBox.Text = station.ConnectionUser;
+        ConnectionPasswordTextBox.Text = station.ConnectionPassword;
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -77,6 +77,8 @@ namespace WinUI
                         return handler;
                     });
 
+                    services.AddHttpClient<IStationInformationService, StationInformationService>();
+
                     services.AddHttpClient<IApiEndpointService, ApiEndpointService>(client =>
                     {
                         string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";

--- a/WinUI/Services/StationInformationService.cs
+++ b/WinUI/Services/StationInformationService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net.Http.Json;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IStationInformationService
+{
+    Task<StationDto?> GetAsync(Guid stationId);
+}
+
+public class StationInformationService(HttpClient httpClient) : IStationInformationService
+{
+    private record StationInfoResponse(StationDto? Data);
+
+    public async Task<StationDto?> GetAsync(Guid stationId)
+    {
+        var request = new { stationId };
+        using var response = await httpClient.PostAsJsonAsync(StationConstants.StationInfoApiUrl, request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<StationInfoResponse>();
+        return result?.Data;
+    }
+}

--- a/WinUI/Services/StationService.cs
+++ b/WinUI/Services/StationService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Linq;
 using WinUI.Constants;
 using WinUI.Models;
 
@@ -22,11 +23,18 @@ public record CreateStationCommand(
 
 public interface IStationService
 {
+    Task<StationDto?> GetFirstAsync();
     Task<StationDto?> CreateAsync(CreateStationCommand command);
 }
 
 public class StationService(HttpClient httpClient) : IStationService
 {
+    public async Task<StationDto?> GetFirstAsync()
+    {
+        var list = await httpClient.GetFromJsonAsync<List<StationDto>>(StationConstants.ApiUrl);
+        return list?.FirstOrDefault();
+    }
+
     public async Task<StationDto?> CreateAsync(CreateStationCommand command)
     {
         using var response = await httpClient.PostAsJsonAsync(StationConstants.ApiUrl, command);


### PR DESCRIPTION
## Summary
- Add station information service and register it in DI
- Load saved station details on settings page load
- Warn if station settings are missing when fetching info and populate fields when available

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bad341e6108324afb38a01fb8c1f26