### PR TITLE
Save station settings separately and persist fetched station info

### DIFF
--- a/WinUI/Pages/Settings/StationSettingsPage.cs
+++ b/WinUI/Pages/Settings/StationSettingsPage.cs
@@ -42,40 +42,55 @@ public partial class StationSettingsPage : UserControl
             return;
         }
 
-        if (!int.TryParse(DataPeriodTextBox.Text, out var dataPeriod))
+        var existing = await _stationService.GetFirstAsync();
+        if (existing == null)
         {
-            MessageBox.Show(StationConstants.InvalidDataPeriodMessage, StationConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            return;
+            var command = new CreateStationCommand(
+                stationId,
+                stationId.ToString(),
+                stationId.ToString(),
+                1,
+                DateTime.Now,
+                ConnectionDomainAddressTextBox.Text,
+                ConnectionPortTextBox.Text,
+                ConnectionUserTextBox.Text,
+                ConnectionPasswordTextBox.Text,
+                string.Empty,
+                DateTime.Now,
+                DateTime.Now,
+                string.Empty,
+                string.Empty);
+
+            var result = await _stationService.CreateAsync(command);
+            if (result != null)
+            {
+                MessageBox.Show("İstasyon ayarları kaydedildi.", StationConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
-
-        if (!DateTime.TryParse(LastDataDateTextBox.Text, out var lastDataDate) ||
-            !DateTime.TryParse(StationSetupDateTextBox.Text, out var birthDate) ||
-            !DateTime.TryParse(SoftwareSetupDateTextBox.Text, out var setupDate))
+        else
         {
-            MessageBox.Show(StationConstants.InvalidDateMessage, StationConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            return;
-        }
+            var command = new UpdateStationCommand(
+                existing.Id,
+                existing.StationId,
+                existing.Code,
+                existing.Name,
+                existing.DataPeriodMinute,
+                existing.LastDataDate,
+                ConnectionDomainAddressTextBox.Text,
+                ConnectionPortTextBox.Text,
+                ConnectionUserTextBox.Text,
+                ConnectionPasswordTextBox.Text,
+                existing.Company,
+                existing.BirtDate,
+                existing.SetupDate,
+                existing.Address,
+                existing.Software);
 
-        var command = new CreateStationCommand(
-            stationId,
-            CodeTextBox.Text,
-            StationNameTextBox.Text,
-            dataPeriod,
-            lastDataDate,
-            CabinSoftwareAddressTextBox.Text,
-            ConnectionPortTextBox.Text,
-            ConnectionUserTextBox.Text,
-            ConnectionPasswordTextBox.Text,
-            OrganizationTextBox.Text,
-            birthDate,
-            setupDate,
-            StationAddressTextBox.Text,
-            SoftwareTextBox.Text);
-
-        var result = await _stationService.CreateAsync(command);
-        if (result != null)
-        {
-            MessageBox.Show(string.Format(StationConstants.StationSavedMessage, result.Name), StationConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            var result = await _stationService.UpdateAsync(command);
+            if (result != null)
+            {
+                MessageBox.Show("İstasyon ayarları kaydedildi.", StationConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
     }
 
@@ -91,6 +106,23 @@ public partial class StationSettingsPage : UserControl
         var info = await _stationInformationService.GetAsync(station.StationId);
         if (info != null)
         {
+            var command = new UpdateStationCommand(
+                station.Id,
+                station.StationId,
+                info.Code,
+                info.Name,
+                info.DataPeriodMinute,
+                info.LastDataDate,
+                station.ConnectionDomainAddress,
+                station.ConnectionPort,
+                station.ConnectionUser,
+                station.ConnectionPassword,
+                info.Company,
+                info.BirtDate,
+                info.SetupDate,
+                info.Address,
+                info.Software);
+            await _stationService.UpdateAsync(command);
             PopulateStationInfo(info);
         }
     }

--- a/WinUI/Services/StationService.cs
+++ b/WinUI/Services/StationService.cs
@@ -21,10 +21,28 @@ public record CreateStationCommand(
     string Address,
     string Software);
 
+public record UpdateStationCommand(
+    int Id,
+    Guid StationId,
+    string Code,
+    string Name,
+    int DataPeriodMinute,
+    DateTime LastDataDate,
+    string ConnectionDomainAddress,
+    string ConnectionPort,
+    string ConnectionUser,
+    string ConnectionPassword,
+    string Company,
+    DateTime BirtDate,
+    DateTime SetupDate,
+    string Address,
+    string Software);
+
 public interface IStationService
 {
     Task<StationDto?> GetFirstAsync();
     Task<StationDto?> CreateAsync(CreateStationCommand command);
+    Task<StationDto?> UpdateAsync(UpdateStationCommand command);
 }
 
 public class StationService(HttpClient httpClient) : IStationService
@@ -38,6 +56,13 @@ public class StationService(HttpClient httpClient) : IStationService
     public async Task<StationDto?> CreateAsync(CreateStationCommand command)
     {
         using var response = await httpClient.PostAsJsonAsync(StationConstants.ApiUrl, command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<StationDto>();
+    }
+
+    public async Task<StationDto?> UpdateAsync(UpdateStationCommand command)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{StationConstants.ApiUrl}/{command.Id}", command);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<StationDto>();
     }


### PR DESCRIPTION
## Summary
- add update support in station service to modify existing station records
- adjust station settings page to save only connection details and update info after fetching

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bad825a758832492113c1cd3009d54