### PR TITLE
Add authentication flow for station information

### DIFF
--- a/WinUI/Constants/StationConstants.cs
+++ b/WinUI/Constants/StationConstants.cs
@@ -12,4 +12,5 @@ public static class StationConstants
     public const string StationIdPlaceholder = "edf10dfd-5fab-460b-b2fd-66b67da7a489";
     public const string StationSettingsRequiredMessage = "Bu servisi kullanabilmeniz için istasyon ayarlarını tanımlamanız gerekmektedir.";
     public const string StationInfoApiUrl = "https://entegrationsais.csb.gov.tr/SAIS/GetStationInformation";
+    public const string Ticket = "f9249e93-3093-4503-a913-09131c806f39";
 }

--- a/WinUI/Pages/Settings/ApiSettingsPage.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.cs
@@ -19,7 +19,6 @@ public partial class ApiSettingsPage : UserControl
     private int? _apiEndpointId;
     private string? _token;
 
-    private const string Ticket = "f9249e93-3093-4503-a913-09131c806f39";
 
     public ApiSettingsPage()
     {
@@ -103,7 +102,7 @@ public partial class ApiSettingsPage : UserControl
             {
                 username = ApiUsernameTextBox.Text,
                 password = ApiPasswordTextBox.Text,
-                ticket = Ticket
+                ticket = StationConstants.Ticket
             };
 
             using var response = await _remoteClient.PostAsJsonAsync(url, loginRequest);
@@ -129,7 +128,7 @@ public partial class ApiSettingsPage : UserControl
     {
         try
         {
-            var body = new { ticket = Ticket };
+            var body = new { ticket = StationConstants.Ticket };
             using var response = await _localClient.PostAsJsonAsync("api/sample/request-start", body);
             var content = await response.Content.ReadAsStringAsync();
             ResponseTextBox.Text = FormatContent(content);
@@ -153,7 +152,7 @@ public partial class ApiSettingsPage : UserControl
             var body = new
             {
                 stationId = "1",
-                ticket = Ticket,
+                ticket = StationConstants.Ticket,
                 desc = "Deneme",
                 stationAlarmId = "0",
                 diagnosticDate = DateTime.Now.ToString("s")

--- a/WinUI/Services/StationInformationService.cs
+++ b/WinUI/Services/StationInformationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Net.Http.Json;
 using WinUI.Constants;
 using WinUI.Models;
@@ -10,14 +11,50 @@ public interface IStationInformationService
     Task<StationDto?> GetAsync(Guid stationId);
 }
 
-public class StationInformationService(HttpClient httpClient) : IStationInformationService
+public class StationInformationService : IStationInformationService
 {
+    private readonly HttpClient _httpClient;
+    private readonly IApiEndpointService _apiEndpointService;
+
     private record StationInfoResponse(StationDto? Data);
+    private record LoginResponse(bool result, string message, string token, int expiresIn);
+
+    public StationInformationService(HttpClient httpClient, IApiEndpointService apiEndpointService)
+    {
+        _httpClient = httpClient;
+        _apiEndpointService = apiEndpointService;
+    }
 
     public async Task<StationDto?> GetAsync(Guid stationId)
     {
-        var request = new { stationId };
-        using var response = await httpClient.PostAsJsonAsync(StationConstants.StationInfoApiUrl, request);
+        var endpoint = await _apiEndpointService.GetFirstAsync();
+        if (endpoint == null)
+        {
+            return null;
+        }
+
+        var loginUrl = $"{endpoint.ApiAddress.TrimEnd('/')}/Security/login";
+        var loginRequest = new
+        {
+            username = endpoint.UserName,
+            password = endpoint.Password,
+            ticket = StationConstants.Ticket
+        };
+
+        using var loginResponse = await _httpClient.PostAsJsonAsync(loginUrl, loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, StationConstants.StationInfoApiUrl);
+        if (!string.IsNullOrEmpty(loginResult?.token))
+        {
+            request.Headers.Add("token", loginResult.token);
+        }
+
+        var body = new { stationId, ticket = StationConstants.Ticket };
+        request.Content = JsonContent.Create(body);
+
+        using var response = await _httpClient.SendAsync(request);
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<StationInfoResponse>();
         return result?.Data;


### PR DESCRIPTION
## Summary
- Centralize SAIS ticket in StationConstants
- Use shared ticket in API settings interactions
- Authenticate and send ticket when fetching station info

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae275fcbc8324acc13bf8baa7c3c4