### PR TITLE
Align diagnostic request with API requirements

### DIFF
--- a/WinUI/Models/ApiDiagnosticDto.cs
+++ b/WinUI/Models/ApiDiagnosticDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace WinUI.Models;
+
+public class ApiDiagnosticDto
+{
+    public DateTime? startDate { get; set; }
+    public DateTime? endDate { get; set; }
+    public Guid stationId { get; set; }
+    public string details { get; set; } = string.Empty;
+    public int? diagnosticTypeNo { get; set; }
+}


### PR DESCRIPTION
## Summary
- send diagnostics using new `ApiDiagnosticDto` model
- include station ID and AToken header when calling `SAIS/SendDiagnostic`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be912fbed48324beb477ffeb4d7ad0