### PR TITLE
Refactor database settings with async search and persistence

### DIFF
--- a/WinUI/Models/DatabaseInfo.cs
+++ b/WinUI/Models/DatabaseInfo.cs
@@ -1,0 +1,3 @@
+namespace WinUI.Models;
+
+public record DatabaseInfo(string Server, string? DatabaseName, int? StorageUsageMb);

--- a/WinUI/Pages/SettingsPage.cs
+++ b/WinUI/Pages/SettingsPage.cs
@@ -12,6 +12,8 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using WinUI.Helpers;
 using WinUI.Pages.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using WinUI.Services;
 
 namespace WinUI.Pages;
 
@@ -70,7 +72,9 @@ public partial class SettingsPage : UserControl
 
     private void DatabaseButton_Click(object sender, EventArgs e)
     {
-        PageManager.ShowPage(this.PanelContent, new DatabaseSettingsPage());
+        var searchEngine = Program.Services!.GetRequiredService<IDatabaseSearchEngine>();
+        var selectionService = Program.Services!.GetRequiredService<IDatabaseSelectionService>();
+        PageManager.ShowPage(this.PanelContent, new DatabaseSettingsPage(searchEngine, selectionService));
     }
 
     private void ApiButton_Click(object sender, EventArgs e)

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -96,6 +96,9 @@ namespace WinUI
                     });
 
                     services.AddHttpClient<ITicketService, TicketService>();
+
+                    services.AddSingleton<IDatabaseSearchEngine, SqlDatabaseSearchEngine>();
+                    services.AddSingleton<IDatabaseSelectionService, DatabaseSelectionService>();
                 });
     }
 }

--- a/WinUI/Services/DatabaseSelectionService.cs
+++ b/WinUI/Services/DatabaseSelectionService.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace WinUI.Services;
+
+public class DatabaseSelectionService : IDatabaseSelectionService
+{
+    private readonly string _filePath;
+
+    public DatabaseSelectionService()
+    {
+        _filePath = Path.Combine(AppContext.BaseDirectory, "database.config");
+        if (File.Exists(_filePath))
+        {
+            SelectedServer = File.ReadAllText(_filePath).Trim();
+        }
+    }
+
+    public string? SelectedServer { get; private set; }
+
+    public async Task SaveSelectedServerAsync(string server)
+    {
+        SelectedServer = server;
+        await File.WriteAllTextAsync(_filePath, server);
+    }
+}

--- a/WinUI/Services/IDatabaseSearchEngine.cs
+++ b/WinUI/Services/IDatabaseSearchEngine.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IDatabaseSearchEngine
+{
+    Task<IEnumerable<string>> SearchServersAsync();
+    Task<DatabaseInfo?> GetDatabaseInfoAsync(string server);
+}

--- a/WinUI/Services/IDatabaseSelectionService.cs
+++ b/WinUI/Services/IDatabaseSelectionService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace WinUI.Services;
+
+public interface IDatabaseSelectionService
+{
+    string? SelectedServer { get; }
+    Task SaveSelectedServerAsync(string server);
+}

--- a/WinUI/Services/SqlDatabaseSearchEngine.cs
+++ b/WinUI/Services/SqlDatabaseSearchEngine.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Sql;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public class SqlDatabaseSearchEngine : IDatabaseSearchEngine
+{
+    public async Task<IEnumerable<string>> SearchServersAsync()
+    {
+        return await Task.Run(() =>
+        {
+            var servers = new List<string>();
+            DataTable table = SqlDataSourceEnumerator.Instance.GetDataSources();
+            foreach (DataRow row in table.Rows)
+            {
+                string server = row["ServerName"].ToString()!;
+                string instance = row["InstanceName"].ToString();
+                string full = string.IsNullOrEmpty(instance) ? server : $"{server}\\{instance}";
+                servers.Add(full);
+            }
+            return (IEnumerable<string>)servers;
+        });
+    }
+
+    public async Task<DatabaseInfo?> GetDatabaseInfoAsync(string server)
+    {
+        try
+        {
+            using SqlConnection connection = new($"Server={server};Integrated Security=true;");
+            await connection.OpenAsync();
+
+            using SqlCommand command = new("SELECT DB_NAME(); SELECT SUM(size)*8/1024 FROM sys.database_files", connection);
+            using SqlDataReader reader = await command.ExecuteReaderAsync();
+
+            string? databaseName = null;
+            int? size = null;
+
+            if (await reader.ReadAsync())
+            {
+                databaseName = reader.GetString(0);
+            }
+
+            if (await reader.NextResultAsync() && await reader.ReadAsync())
+            {
+                size = reader.GetInt32(0);
+            }
+
+            return new DatabaseInfo(server, databaseName, size);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IDatabaseSearchEngine` and `SqlDatabaseSearchEngine` for async SQL server discovery
- add `DatabaseSelectionService` to persist selected server
- wire up `DatabaseSettingsPage` and `SettingsPage` to use these services via DI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec714df3c8324908b98acbc0ff514