### PR TITLE
Disable save button during server search

### DIFF
--- a/WinUI/Pages/Settings/DatabaseSettingsPage.cs
+++ b/WinUI/Pages/Settings/DatabaseSettingsPage.cs
@@ -64,6 +64,8 @@ namespace WinUI.Pages.Settings
                 ServerAddressComboBox.Text = currentText;
             }
             ServerAddressComboBox.Enabled = false;
+            SaveDatabaseButton.Enabled = false;
+            SaveDatabaseButton.Text = "Lütfen bekleyin";
 
             try
             {
@@ -95,6 +97,8 @@ namespace WinUI.Pages.Settings
             finally
             {
                 ServerAddressComboBox.Enabled = true;
+                SaveDatabaseButton.Text = "Kaydet";
+                SaveDatabaseButton.Enabled = true;
             }
         }
 


### PR DESCRIPTION
## Summary
- Disable database settings save button while scanning for servers and show "Lütfen bekleyin"
- Restore text and enable button after server list is loaded

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bedfc8c3788324b38dc0f9499d96ad