### PR TITLE
Load logs into reporting page for record type

### DIFF
--- a/WinUI/Constants/LogsConstants.cs
+++ b/WinUI/Constants/LogsConstants.cs
@@ -1,0 +1,6 @@
+namespace WinUI.Constants;
+
+public static class LogsConstants
+{
+    public const string ApiUrl = "api/logs";
+}

--- a/WinUI/Pages/ReportingPage.cs
+++ b/WinUI/Pages/ReportingPage.cs
@@ -1,34 +1,78 @@
+using WinUI.Models;
+using WinUI.Services;
+
 namespace WinUI.Pages
 {
     public partial class ReportingPage : UserControl
     {
-        public ReportingPage()
+        private readonly ILogService _logService;
+
+        public ReportingPage(ILogService logService)
         {
+            _logService = logService;
             InitializeComponent();
         }
 
         private void ReportingPage_Load(object sender, EventArgs e)
         {
+            ComboBoxReportType.Items.AddRange(new object[] { "Analog", "Dijital", "Kayıt" });
+            ComboBoxReportType.SelectedIndex = 0;
+            RadioButtonDaily.Checked = true;
         }
 
         private void RadioButtonCustom_CheckedChanged(object sender, EventArgs e)
         {
+            GroupBoxDate.Enabled = RadioButtonCustom.Checked;
         }
 
         private void RadioButtonMonthly_CheckedChanged(object sender, EventArgs e)
         {
+            GroupBoxDate.Enabled = false;
         }
 
         private void RadioButtonWeekly_CheckedChanged(object sender, EventArgs e)
         {
+            GroupBoxDate.Enabled = false;
         }
 
         private void RadioButtonDaily_CheckedChanged(object sender, EventArgs e)
         {
+            GroupBoxDate.Enabled = false;
         }
 
         private async void ButtonGenerate_Click(object sender, EventArgs e)
         {
+            if (ComboBoxReportType.SelectedItem?.ToString() != "Kayıt")
+                return;
+
+            DateTime start;
+            DateTime end;
+
+            if (RadioButtonDaily.Checked)
+            {
+                end = DateTime.Now;
+                start = end.Date;
+            }
+            else if (RadioButtonWeekly.Checked)
+            {
+                end = DateTime.Now;
+                start = end.AddDays(-7);
+            }
+            else if (RadioButtonMonthly.Checked)
+            {
+                end = DateTime.Now;
+                start = end.AddMonths(-1);
+            }
+            else
+            {
+                start = DateTimePickerFirstDate.Value.Date + DateTimePickerFirstTime.Value.TimeOfDay;
+                end = DateTimePickerLastDate.Value.Date + DateTimePickerLastTime.Value.TimeOfDay;
+            }
+
+            bool descending = RadioButtonSortByLast.Checked;
+            var logs = await _logService.GetAsync(start, end, descending) ?? new List<LogDto>();
+            DataGridViewDatas.AutoGenerateColumns = true;
+            DataGridViewDatas.DataSource = logs;
         }
 
         private void ButtonSaveAsExcel_Click(object sender, EventArgs e)

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -113,6 +113,22 @@ namespace WinUI
                         return handler;
                     });
 
+                    services.AddHttpClient<ILogService, LogService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                        baseUrl = baseUrl.TrimEnd('/');
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        }
+                        return handler;
+                    });
+
                     services.AddHttpClient<ITicketService, TicketService>();
 
                     services.AddSingleton<IDatabaseSearchEngine, SqlDatabaseSearchEngine>();

--- a/WinUI/Services/LogService.cs
+++ b/WinUI/Services/LogService.cs
@@ -1,0 +1,19 @@
+using System.Net.Http.Json;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface ILogService
+{
+    Task<List<LogDto>?> GetAsync(DateTime startDate, DateTime endDate, bool descending);
+}
+
+public class LogService(HttpClient httpClient) : ILogService
+{
+    public async Task<List<LogDto>?> GetAsync(DateTime startDate, DateTime endDate, bool descending)
+    {
+        string url = $"{LogsConstants.ApiUrl}?startDate={startDate:o}&endDate={endDate:o}&descending={descending}";
+        return await httpClient.GetFromJsonAsync<List<LogDto>>(url);
+    }
+}


### PR DESCRIPTION
## Summary
- Add logs constant and service to query `/api/logs`
- Register log service and hook up Reporting page to fetch logs when "Kayıt" measurement type is chosen
- Populate report type choices and support basic period selection

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdc155c7483248a0f792afc051e8f