### PR TITLE
Add sensor status code enumerations and priority helper

### DIFF
--- a/Domain/Enums/InvalidSensorStatusCode.cs
+++ b/Domain/Enums/InvalidSensorStatusCode.cs
@@ -1,0 +1,28 @@
+namespace Domain.Enums;
+
+/// <summary>
+/// Geçersiz durum kodları.
+/// </summary>
+public enum InvalidSensorStatusCode
+{
+    /// <summary>Eksik/geçersiz yıkama bilgisi.</summary>
+    GecersizYikama = 200,
+
+    /// <summary>Eksik/geçersiz haftalık yıkama bilgisi.</summary>
+    GecersizHaftalikYikama = 201,
+
+    /// <summary>Eksik/geçersiz aylık kalibrasyon bilgisi.</summary>
+    GecersizKalibrasyon = 202,
+
+    /// <summary>Geçersiz akış hızı.</summary>
+    GecersizAkisHizi = 203,
+
+    /// <summary>Geçersiz debi değeri.</summary>
+    GecersizDebi = 204,
+
+    /// <summary>Mükerrer veri.</summary>
+    TekrarVeri = 205,
+
+    /// <summary>Uygunsuz ölçüm birimi.</summary>
+    GecersizOlcumBirimi = 206
+}

--- a/Domain/Enums/SensorStatusCode.cs
+++ b/Domain/Enums/SensorStatusCode.cs
@@ -1,0 +1,67 @@
+namespace Domain.Enums;
+
+/// <summary>
+/// Temel durum kodları for measurement channels.
+/// </summary>
+public enum SensorStatusCode
+{
+    /// <summary>Veri toplama ve kayıt sistemi çalışmıyor.</summary>
+    VeriYok = 0,
+
+    /// <summary>Geçerli ölçüm verisi (%80 geçerli veri koşulu sağlanmış).</summary>
+    VeriGecerli = 1,
+
+    /// <summary>Ölçüm verisi geçersiz. Ölçüm kanalında alarm var.</summary>
+    Gecersiz = 4,
+
+    /// <summary>Kalibrasyon uyarı eşiği aşıldı. 5 tekrar sonrası KalHatasi koduna geçer.</summary>
+    KalLimitDisi = 7,
+
+    /// <summary>Cihaz ile iletişim yok veya veri gelmiyor.</summary>
+    IletisimHatasi = 8,
+
+    /// <summary>Analizör kalibrasyonda.</summary>
+    SistemKal = 9,
+
+    /// <summary>Ölçümü etkileyen alarm, diğer kodlarla eşleşmiyorsa kullanılır.</summary>
+    Alarm = 12,
+
+    /// <summary>Cihaz purge modunda.</summary>
+    Purge = 15,
+
+    /// <summary>Kalibrasyon hatası. Sonraki kalibrasyona kadar sabit kalır.</summary>
+    KalHatasi = 19,
+
+    /// <summary>Akış ölçerde hata.</summary>
+    AkisYok = 21,
+
+    /// <summary>Deşarj yapılmıyor.</summary>
+    DesarjYok = 22,
+
+    /// <summary>Günlük yıkama sırasında.</summary>
+    Yikama = 23,
+
+    /// <summary>Haftalık yıkama sırasında.</summary>
+    HaftalikYikama = 24,
+
+    /// <summary>İstasyon bakımda.</summary>
+    IstasyonBakimda = 25,
+
+    /// <summary>Tesis bakımda.</summary>
+    TesisBakimda = 26,
+
+    /// <summary>Cihaz bakımda.</summary>
+    CihazBakimda = 30,
+
+    /// <summary>Debide arıza var.</summary>
+    DebiArizasi = 31,
+
+    /// <summary>1. nokta kalibrasyonu.</summary>
+    Nokta1Kalibrasyon = 35,
+
+    /// <summary>2. nokta kalibrasyonu.</summary>
+    Nokta2Kalibrasyon = 36,
+
+    /// <summary>Ölçüm cihaz aralığı dışında.</summary>
+    OlcumAraligiDisinda = 39
+}

--- a/Domain/Enums/SensorStatusCodeExtensions.cs
+++ b/Domain/Enums/SensorStatusCodeExtensions.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Domain.Enums;
+
+/// <summary>
+/// Helper methods for <see cref="SensorStatusCode"/>.
+/// </summary>
+public static class SensorStatusCodeExtensions
+{
+    private static readonly SensorStatusCode[] PriorityOrder = new[]
+    {
+        SensorStatusCode.Purge,
+        SensorStatusCode.Yikama,
+        SensorStatusCode.HaftalikYikama,
+        SensorStatusCode.DebiArizasi
+    };
+
+    /// <summary>
+    /// Returns the highest priority code from the given collection.
+    /// </summary>
+    public static SensorStatusCode GetPriorityCode(IEnumerable<SensorStatusCode> codes)
+    {
+        foreach (var priority in PriorityOrder)
+        {
+            if (codes.Contains(priority))
+                return priority;
+        }
+
+        return codes.FirstOrDefault();
+    }
+}


### PR DESCRIPTION
## Summary
- define basic sensor status codes
- add invalid sensor status codes
- provide helper for prioritizing status codes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f83235483249678ef235281cfd4