### PR TITLE
Add calibration UI and services

### DIFF
--- a/WinUI/Constants/CalibrationLimitConstants.cs
+++ b/WinUI/Constants/CalibrationLimitConstants.cs
@@ -1,0 +1,6 @@
+namespace WinUI.Constants;
+
+public static class CalibrationLimitConstants
+{
+    public const string ApiUrl = "api/calibrationlimits";
+}

--- a/WinUI/Constants/CalibrationMeasurementConstants.cs
+++ b/WinUI/Constants/CalibrationMeasurementConstants.cs
@@ -1,0 +1,6 @@
+namespace WinUI.Constants;
+
+public static class CalibrationMeasurementConstants
+{
+    public const string ApiUrl = "api/calibrationmeasurements";
+}

--- a/WinUI/Models/CalibrationLimitDto.cs
+++ b/WinUI/Models/CalibrationLimitDto.cs
@@ -1,0 +1,11 @@
+namespace WinUI.Models;
+
+public class CalibrationLimitDto
+{
+    public int Id { get; set; }
+    public string Parameter { get; set; } = string.Empty;
+    public int ZeroRef { get; set; }
+    public int ZeroTimeStamp { get; set; }
+    public int SpanRef { get; set; }
+    public int SpanTimeStamp { get; set; }
+}

--- a/WinUI/Models/CalibrationMeasurementDto.cs
+++ b/WinUI/Models/CalibrationMeasurementDto.cs
@@ -1,0 +1,18 @@
+namespace WinUI.Models;
+
+public class CalibrationMeasurementDto
+{
+    public int Id { get; set; }
+    public DateTime TimeStamp { get; set; }
+    public string Parameter { get; set; } = string.Empty;
+    public double ZeroRef { get; set; }
+    public double ZeroMeas { get; set; }
+    public double ZeroDiff { get; set; }
+    public double ZeroStd { get; set; }
+    public double SpanRef { get; set; }
+    public double SpanMeas { get; set; }
+    public double SpanDiff { get; set; }
+    public double SpanStd { get; set; }
+    public double ResultFactor { get; set; }
+    public bool IsItValid { get; set; }
+}

--- a/WinUI/Pages/CalibrationPage.Designer.cs
+++ b/WinUI/Pages/CalibrationPage.Designer.cs
@@ -1448,34 +1448,6 @@ namespace WinUI.Pages
             ResumeLayout(false);
         }
 
-        private void CalibrationPage_Load(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonAkmZero_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonPhZero_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonPhSpan_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonIletkenlikZero_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonIletkenlikSpan_Click(object sender, EventArgs e)
-        {
-        }
-
-        private void ButtonKoiZero_Click(object sender, EventArgs e)
-        {
-        }
-
         #endregion
 
         private TableLayoutPanel tableLayoutPanel1;

--- a/WinUI/Pages/CalibrationPage.cs
+++ b/WinUI/Pages/CalibrationPage.cs
@@ -1,20 +1,159 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Windows.Forms.DataVisualization.Charting;
+using Microsoft.Extensions.DependencyInjection;
+using WinUI.Models;
+using WinUI.Services;
 
 namespace WinUI.Pages
 {
     public partial class CalibrationPage: UserControl
     {
+        private readonly ISaisApiService _saisApiService;
+        private readonly ICalibrationMeasurementService _calibrationMeasurementService;
+        private readonly ICalibrationLimitService _calibrationLimitService;
+        private readonly IStationService _stationService;
+        private CalibrationLimitDto? _phLimit;
+        private CalibrationLimitDto? _conductivityLimit;
+        private CalibrationRequest? _currentRequest;
+        private Timer? _timer;
+        private int _elapsed;
+        private bool _isZero;
+        private string _activeParameter = string.Empty;
+
         public CalibrationPage()
         {
             InitializeComponent();
+
+            _saisApiService = Program.Services.GetRequiredService<ISaisApiService>();
+            _calibrationMeasurementService = Program.Services.GetRequiredService<ICalibrationMeasurementService>();
+            _calibrationLimitService = Program.Services.GetRequiredService<ICalibrationLimitService>();
+            _stationService = Program.Services.GetRequiredService<IStationService>();
+
+            Load += CalibrationPage_Load;
+            ButtonPhZero.Click += ButtonPhZero_Click;
+            ButtonPhSpan.Click += ButtonPhSpan_Click;
+            ButtonIletkenlikZero.Click += ButtonIletkenlikZero_Click;
+            ButtonIletkenlikSpan.Click += ButtonIletkenlikSpan_Click;
+        }
+
+        private async void CalibrationPage_Load(object? sender, EventArgs e)
+        {
+            var limits = await _calibrationLimitService.GetListAsync();
+            _phLimit = limits?.FirstOrDefault(x => x.Parameter.Equals("pH", StringComparison.OrdinalIgnoreCase));
+            _conductivityLimit = limits?.FirstOrDefault(x => x.Parameter.Equals("Iletkenlik", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private void ButtonPhZero_Click(object? sender, EventArgs e) => StartCalibration("pH", true, _phLimit);
+        private void ButtonPhSpan_Click(object? sender, EventArgs e) => StartCalibration("pH", false, _phLimit);
+        private void ButtonIletkenlikZero_Click(object? sender, EventArgs e) => StartCalibration("Iletkenlik", true, _conductivityLimit);
+        private void ButtonIletkenlikSpan_Click(object? sender, EventArgs e) => StartCalibration("Iletkenlik", false, _conductivityLimit);
+
+        private void StartCalibration(string parameter, bool zero, CalibrationLimitDto? limit)
+        {
+            if (limit == null)
+                return;
+
+            _activeParameter = parameter;
+            _isZero = zero;
+            _elapsed = 0;
+            _currentRequest ??= new CalibrationRequest
+            {
+                CalibrationDate = DateTime.Now,
+                DBColumnName = parameter,
+                StationId = Guid.Empty
+            };
+
+            ChartCalibration.Series.Clear();
+            var series = new Series(zero ? "Zero" : "Span") { ChartType = SeriesChartType.Line };
+            ChartCalibration.Series.Add(series);
+
+            _timer?.Stop();
+            _timer = new Timer { Interval = 1000 };
+            _timer.Tick += (s, e) => TimerTick(limit);
+            _timer.Start();
+        }
+
+        private void TimerTick(CalibrationLimitDto limit)
+        {
+            _elapsed++;
+            double reference = _isZero ? limit.ZeroRef : limit.SpanRef;
+            var rnd = new Random();
+            double measurement = reference + rnd.NextDouble() * reference * 0.2 - reference * 0.1;
+            double diff = measurement - reference;
+            double percent = Math.Abs(diff) / reference * 100.0;
+
+            var series = ChartCalibration.Series[0];
+            series.Color = percent <= 10 ? System.Drawing.Color.Green : System.Drawing.Color.Red;
+            series.Points.AddY(measurement);
+
+            if (_isZero)
+            {
+                CalibrationStatusBarZero.ZeroRef = reference.ToString("F2");
+                CalibrationStatusBarZero.ZeroMeas = measurement.ToString("F2");
+                CalibrationStatusBarZero.ZeroDiff = diff.ToString("F2");
+                CalibrationStatusBarZero.ZeroStd = "0";
+
+                _currentRequest!.ZeroRef = reference;
+                _currentRequest.ZeroMeas = measurement;
+                _currentRequest.ZeroDiff = diff;
+                _currentRequest.ZeroSTD = 0;
+            }
+            else
+            {
+                CalibrationStatusBarSpan.SpanRef = reference.ToString("F2");
+                CalibrationStatusBarSpan.SpanMeas = measurement.ToString("F2");
+                CalibrationStatusBarSpan.SpanDiff = diff.ToString("F2");
+                CalibrationStatusBarSpan.SpanStd = "0";
+
+                _currentRequest!.SpanRef = reference;
+                _currentRequest.SpanMeas = measurement;
+                _currentRequest.SpanDiff = diff;
+                _currentRequest.SpanSTD = 0;
+            }
+
+            if (_elapsed >= (_isZero ? limit.ZeroTimeStamp : limit.SpanTimeStamp))
+            {
+                _timer!.Stop();
+                if (_isZero)
+                    StartCalibration(_activeParameter, false, limit);
+                else
+                    FinishCalibration();
+            }
+        }
+
+        private async void FinishCalibration()
+        {
+            if (_currentRequest == null)
+                return;
+
+            _currentRequest.ResultFactor = _currentRequest.SpanMeas == 0 ? 0 : _currentRequest.SpanRef / _currentRequest.SpanMeas;
+            _currentRequest.ResultZero = Math.Abs(_currentRequest.ZeroDiff) / _currentRequest.ZeroRef * 100 <= 10;
+            _currentRequest.ResultSpan = Math.Abs(_currentRequest.SpanDiff) / _currentRequest.SpanRef * 100 <= 10;
+
+            var station = await _stationService.GetFirstAsync();
+            if (station != null)
+            {
+                _currentRequest.StationId = station.StationId;
+            }
+
+            await _saisApiService.SendCalibrationAsync(_currentRequest);
+            await _calibrationMeasurementService.CreateAsync(new CreateCalibrationMeasurementCommand(
+                _currentRequest.CalibrationDate,
+                _currentRequest.DBColumnName,
+                _currentRequest.ZeroRef,
+                _currentRequest.ZeroMeas,
+                _currentRequest.ZeroDiff,
+                _currentRequest.ZeroSTD,
+                _currentRequest.SpanRef,
+                _currentRequest.SpanMeas,
+                _currentRequest.SpanDiff,
+                _currentRequest.SpanSTD,
+                _currentRequest.ResultFactor,
+                _currentRequest.ResultZero && _currentRequest.ResultSpan));
+
+            _currentRequest = null;
         }
     }
 }

--- a/WinUI/Pages/Settings/CalibrationSettingsPage.cs
+++ b/WinUI/Pages/Settings/CalibrationSettingsPage.cs
@@ -1,20 +1,74 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using Microsoft.Extensions.DependencyInjection;
+using WinUI.Models;
+using WinUI.Services;
 
 namespace WinUI.Pages.Settings
 {
     public partial class CalibrationSettingsPage : UserControl
     {
+        private readonly ICalibrationLimitService _calibrationLimitService;
+        private CalibrationLimitDto? _phLimit;
+        private CalibrationLimitDto? _conductivityLimit;
+
         public CalibrationSettingsPage()
         {
             InitializeComponent();
+
+            _calibrationLimitService = Program.Services.GetRequiredService<ICalibrationLimitService>();
+
+            Load += CalibrationSettingsPage_Load;
+            SaveCalibrationButton.Click += SaveCalibrationButton_Click;
+        }
+
+        private async void CalibrationSettingsPage_Load(object? sender, EventArgs e)
+        {
+            var list = await _calibrationLimitService.GetListAsync();
+            _phLimit = list?.FirstOrDefault(x => x.Parameter.Equals("pH", StringComparison.OrdinalIgnoreCase));
+            _conductivityLimit = list?.FirstOrDefault(x => x.Parameter.Equals("Iletkenlik", StringComparison.OrdinalIgnoreCase));
+
+            if (_phLimit != null)
+            {
+                PhZeroTextBox.Text = _phLimit.ZeroRef.ToString();
+                PhSpanComboBox.Text = _phLimit.SpanRef.ToString();
+            }
+
+            if (_conductivityLimit != null)
+            {
+                ConductivityZeroTextBox.Text = _conductivityLimit.ZeroRef.ToString();
+                ConductivitySpanTextBox.Text = _conductivityLimit.SpanRef.ToString();
+            }
+        }
+
+        private async void SaveCalibrationButton_Click(object? sender, EventArgs e)
+        {
+            if (_phLimit != null)
+            {
+                _phLimit.ZeroRef = int.Parse(PhZeroTextBox.Text);
+                _phLimit.SpanRef = int.Parse(PhSpanComboBox.Text);
+                await _calibrationLimitService.UpdateAsync(new UpdateCalibrationLimitCommand(_phLimit.Id, _phLimit.Parameter, _phLimit.ZeroRef, _phLimit.ZeroTimeStamp, _phLimit.SpanRef, _phLimit.SpanTimeStamp));
+            }
+            else
+            {
+                var cmd = new CreateCalibrationLimitCommand("pH", int.Parse(PhZeroTextBox.Text), 60, int.Parse(PhSpanComboBox.Text), 60);
+                _phLimit = await _calibrationLimitService.CreateAsync(cmd);
+            }
+
+            if (_conductivityLimit != null)
+            {
+                _conductivityLimit.ZeroRef = int.Parse(ConductivityZeroTextBox.Text);
+                _conductivityLimit.SpanRef = int.Parse(ConductivitySpanTextBox.Text);
+                await _calibrationLimitService.UpdateAsync(new UpdateCalibrationLimitCommand(_conductivityLimit.Id, _conductivityLimit.Parameter, _conductivityLimit.ZeroRef, _conductivityLimit.ZeroTimeStamp, _conductivityLimit.SpanRef, _conductivityLimit.SpanTimeStamp));
+            }
+            else
+            {
+                var cmd2 = new CreateCalibrationLimitCommand("Iletkenlik", int.Parse(ConductivityZeroTextBox.Text), 60, int.Parse(ConductivitySpanTextBox.Text), 60);
+                _conductivityLimit = await _calibrationLimitService.CreateAsync(cmd2);
+            }
+
+            MessageBox.Show("Kalibrasyon değerleri kaydedildi.", "Bilgi", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -130,6 +130,38 @@ namespace WinUI
                         return handler;
                     });
 
+                    services.AddHttpClient<ICalibrationMeasurementService, CalibrationMeasurementService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                        baseUrl = baseUrl.TrimEnd('/');
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        }
+                        return handler;
+                    });
+
+                    services.AddHttpClient<ICalibrationLimitService, CalibrationLimitService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                        baseUrl = baseUrl.TrimEnd('/');
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                        }
+                        return handler;
+                    });
+
                     services.AddHttpClient<ITicketService, TicketService>();
 
                     services.AddSingleton<IReportExportService, ReportExportService>();

--- a/WinUI/Services/CalibrationLimitService.cs
+++ b/WinUI/Services/CalibrationLimitService.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public record CreateCalibrationLimitCommand(
+    string Parameter,
+    int ZeroRef,
+    int ZeroTimeStamp,
+    int SpanRef,
+    int SpanTimeStamp);
+
+public record UpdateCalibrationLimitCommand(
+    int Id,
+    string Parameter,
+    int ZeroRef,
+    int ZeroTimeStamp,
+    int SpanRef,
+    int SpanTimeStamp);
+
+public interface ICalibrationLimitService
+{
+    Task<List<CalibrationLimitDto>?> GetListAsync();
+    Task<CalibrationLimitDto?> CreateAsync(CreateCalibrationLimitCommand command);
+    Task<CalibrationLimitDto?> UpdateAsync(UpdateCalibrationLimitCommand command);
+}
+
+public class CalibrationLimitService(HttpClient httpClient) : ICalibrationLimitService
+{
+    public async Task<List<CalibrationLimitDto>?> GetListAsync()
+    {
+        return await httpClient.GetFromJsonAsync<List<CalibrationLimitDto>>(CalibrationLimitConstants.ApiUrl);
+    }
+
+    public async Task<CalibrationLimitDto?> CreateAsync(CreateCalibrationLimitCommand command)
+    {
+        using var response = await httpClient.PostAsJsonAsync(CalibrationLimitConstants.ApiUrl, command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<CalibrationLimitDto>();
+    }
+
+    public async Task<CalibrationLimitDto?> UpdateAsync(UpdateCalibrationLimitCommand command)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{CalibrationLimitConstants.ApiUrl}/{command.Id}", command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<CalibrationLimitDto>();
+    }
+}

--- a/WinUI/Services/CalibrationMeasurementService.cs
+++ b/WinUI/Services/CalibrationMeasurementService.cs
@@ -1,0 +1,34 @@
+using System.Net.Http.Json;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public record CreateCalibrationMeasurementCommand(
+    DateTime TimeStamp,
+    string Parameter,
+    double ZeroRef,
+    double ZeroMeas,
+    double ZeroDiff,
+    double ZeroStd,
+    double SpanRef,
+    double SpanMeas,
+    double SpanDiff,
+    double SpanStd,
+    double ResultFactor,
+    bool IsItValid);
+
+public interface ICalibrationMeasurementService
+{
+    Task<CalibrationMeasurementDto?> CreateAsync(CreateCalibrationMeasurementCommand command);
+}
+
+public class CalibrationMeasurementService(HttpClient httpClient) : ICalibrationMeasurementService
+{
+    public async Task<CalibrationMeasurementDto?> CreateAsync(CreateCalibrationMeasurementCommand command)
+    {
+        using var response = await httpClient.PostAsJsonAsync(CalibrationMeasurementConstants.ApiUrl, command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<CalibrationMeasurementDto>();
+    }
+}


### PR DESCRIPTION
## Summary
- implement calibration measurement and limit services with DTOs and API constants
- enable calibration settings page to store zero/span references
- add calibration page logic to simulate zero/span calibrations and send records

## Testing
- `dotnet build -c Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c15b4eda6c832486ba25c224b40e83