### PR TITLE
fix: show PLC data on home page

### DIFF
--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -86,7 +86,8 @@ namespace WinUI.Pages
         {
             try
             {
-                if (DateTime.Now >= StationConstants.TicketExpiry)
+                if (StationConstants.TicketExpiry != DateTime.MinValue &&
+                    DateTime.Now >= StationConstants.TicketExpiry)
                 {
                     digitalSensorBar1.DataStateDescription = "HATA";
                     digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;


### PR DESCRIPTION
## Summary
- skip ticket expiry check until the station ticket is initialized so PLC data populates on the home page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c16679c06c8324a0479c247980fa56