### PR TITLE
Handle missing PLC configuration and log API errors

### DIFF
--- a/Api/Controllers/PlcDataController.cs
+++ b/Api/Controllers/PlcDataController.cs
@@ -11,8 +11,14 @@ public class PlcDataController(IMediator mediator, IConfiguration configuration)
     [HttpPost("read")]
     public async Task<IActionResult> ReadAndSave()
     {
+        var ipAddress = configuration["PlcSettings:IpAddress"];
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            return NotFound();
+        }
+
         var cmd = new ReadAndSavePlcDataCommand(
-            configuration["PlcSettings:IpAddress"] ?? "10.33.6.253",
+            ipAddress,
             configuration.GetValue<int>("PlcSettings:AnalogDb"),
             configuration.GetValue<int>("PlcSettings:AnalogStart"),
             configuration.GetValue<int>("PlcSettings:AnalogLength"),

--- a/WinUI/Services/PlcDataService.cs
+++ b/WinUI/Services/PlcDataService.cs
@@ -27,7 +27,14 @@ public class PlcDataService : IPlcDataService
             Log.Warning("PLC bilgileri bulunamadı");
             throw new InvalidOperationException("PLC_NOT_CONFIGURED");
         }
-        response.EnsureSuccessStatusCode();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync();
+            Log.Error("PLC API hatası {StatusCode}: {Error}", response.StatusCode, error);
+            throw new HttpRequestException("PLC API request failed");
+        }
+
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         return await response.Content.ReadFromJsonAsync<PlcDataDto>(options);
     }


### PR DESCRIPTION
## Summary
- Return 404 when PLC settings are missing instead of defaulting to a hardcoded IP.
- Log error details on non-success PLC API responses and throw a clear HttpRequestException.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c16a7408708324962e7f6f2feac4d8