### PR TITLE
Fix log service query formatting to prevent 404

### DIFF
--- a/WinUI/Services/LogService.cs
+++ b/WinUI/Services/LogService.cs
@@ -2,6 +2,8 @@ using System.Net.Http.Json;
 using WinUI.Constants;
 using WinUI.Models;
 
+using System;
+
 namespace WinUI.Services;
 
 public interface ILogService
@@ -13,7 +15,9 @@ public class LogService(HttpClient httpClient) : ILogService
 {
     public async Task<List<LogDto>?> GetAsync(DateTime startDate, DateTime endDate, bool descending)
     {
-        string url = $"{LogsConstants.ApiUrl}?startDate={startDate}&endDate={endDate}&descending={descending}";
-        return await httpClient.GetFromJsonAsync<List<LogDto>>(url);
+        string url = $"{LogsConstants.ApiUrl}?startDate={Uri.EscapeDataString(startDate.ToString("O"))}&endDate={Uri.EscapeDataString(endDate.ToString("O"))}&descending={descending}";
+        var response = await httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<List<LogDto>>();
     }
 }


### PR DESCRIPTION
## Summary
- encode log query parameters using ISO 8601 format
- check HTTP response status before deserializing log data

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4292be1208324bd3df07aac70e6e9