### PR TITLE
Add edit/delete actions for user management

### DIFF
--- a/WinUI/Constants/UserConstants.cs
+++ b/WinUI/Constants/UserConstants.cs
@@ -6,4 +6,7 @@ public static class UserConstants
     public const string InfoTitle = "Bilgi";
     public const string ErrorTitle = "Hata";
     public const string UserSavedMessage = "Kullanıcı '{0}' kaydedildi.";
+    public const string UserUpdatedMessage = "Kullanıcı '{0}' güncellendi.";
+    public const string UserDeletedMessage = "Kullanıcı '{0}' silindi.";
+    public const string UserDeleteConfirmMessage = "Silmek istediğinize emin misiniz?";
 }

--- a/WinUI/Services/UserService.cs
+++ b/WinUI/Services/UserService.cs
@@ -9,10 +9,18 @@ public record CreateUserCommand(
     string Email,
     string Password);
 
+public record UpdateUserCommand(
+    int Id,
+    string UserName,
+    string Email,
+    string Password);
+
 public interface IUserService
 {
     Task<List<UserDto>?> GetListAsync();
     Task<UserDto?> CreateAsync(CreateUserCommand command);
+    Task<UserDto?> UpdateAsync(UpdateUserCommand command);
+    Task DeleteAsync(int id);
 }
 
 public class UserService(HttpClient httpClient) : IUserService
@@ -25,5 +33,18 @@ public class UserService(HttpClient httpClient) : IUserService
         using var response = await httpClient.PostAsJsonAsync(UserConstants.ApiUrl, command);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<UserDto>();
+    }
+
+    public async Task<UserDto?> UpdateAsync(UpdateUserCommand command)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{UserConstants.ApiUrl}/{command.Id}", command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<UserDto>();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        using var response = await httpClient.DeleteAsync($"{UserConstants.ApiUrl}/{id}");
+        response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
## Summary
- Hide user IDs and add edit/delete icon columns in mail user grid
- Allow user update and removal via new service methods
- Enable editing existing users in NewUserForm

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7517ede0c83248008cdf758310a38