### PR TITLE
Refactor mail alarms and fix handler return type

### DIFF
--- a/Application/Features/MailAlarms/Commands/UpdateUser/UpdateUserMailAlarmsCommand.cs
+++ b/Application/Features/MailAlarms/Commands/UpdateUser/UpdateUserMailAlarmsCommand.cs
@@ -2,7 +2,7 @@ using MediatR;
 
 namespace Application.Features.MailAlarms.Commands.UpdateUser;
 
-public class UpdateUserMailAlarmsCommand(int userId, List<int> alarmIds) : IRequest
+public class UpdateUserMailAlarmsCommand(int userId, List<int> alarmIds) : IRequest<Unit>
 {
     public int UserId { get; } = userId;
     public List<int> AlarmIds { get; } = alarmIds;

--- a/Application/Features/MailAlarms/Commands/UpdateUser/UpdateUserMailAlarmsCommandHandler.cs
+++ b/Application/Features/MailAlarms/Commands/UpdateUser/UpdateUserMailAlarmsCommandHandler.cs
@@ -6,7 +6,7 @@ namespace Application.Features.MailAlarms.Commands.UpdateUser;
 
 public class UpdateUserMailAlarmsCommandHandler(
     IMailAlarmRepository alarmRepository,
-    IUserMailAlarmRepository userAlarmRepository) : IRequestHandler<UpdateUserMailAlarmsCommand>
+    IUserMailAlarmRepository userAlarmRepository) : IRequestHandler<UpdateUserMailAlarmsCommand, Unit>
 {
     public async Task<Unit> Handle(UpdateUserMailAlarmsCommand request, CancellationToken cancellationToken)
     {

--- a/WinUI/Constants/MailAlarmConstants.cs
+++ b/WinUI/Constants/MailAlarmConstants.cs
@@ -3,5 +3,11 @@ namespace WinUI.Constants;
 public static class MailAlarmConstants
 {
     public const string ApiUrl = "api/mailalarms";
+    public const string AlarmHeader = "Alarm";
+    public const string LimitHeader = "Limit";
+    public const string ActiveHeader = "Aktif";
+    public const string SaveSuccessMessage = "Alarmlar kaydedildi.";
+    public const string LoadErrorMessage = "Alarmlar yüklenirken hata: {0}";
+    public const string SaveErrorMessage = "Alarmlar kaydedilirken hata: {0}";
 }
 

--- a/WinUI/Pages/MailPage.cs
+++ b/WinUI/Pages/MailPage.cs
@@ -177,28 +177,28 @@ namespace WinUI.Pages
                 alarmsDataGridView.DataSource = alarms;
                 ConfigureAlarmColumns();
                 alarmsDataGridView.ReadOnly = false;
-                alarmsDataGridView.Columns["Name"].ReadOnly = true;
-                alarmsDataGridView.Columns["Limit"].ReadOnly = true;
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Name)].ReadOnly = true;
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Limit)].ReadOnly = true;
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Alarmlar yüklenirken hata: {ex.Message}", UserConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(MailAlarmConstants.LoadErrorMessage, ex.Message), UserConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
         private void ConfigureAlarmColumns()
         {
-            if (alarmsDataGridView.Columns["Id"] != null)
-                alarmsDataGridView.Columns["Id"].Visible = false;
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.Id)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Id)].Visible = false;
 
-            if (alarmsDataGridView.Columns["Name"] != null)
-                alarmsDataGridView.Columns["Name"].HeaderText = "Alarm";
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.Name)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Name)].HeaderText = MailAlarmConstants.AlarmHeader;
 
-            if (alarmsDataGridView.Columns["Limit"] != null)
-                alarmsDataGridView.Columns["Limit"].HeaderText = "Limit";
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.Limit)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Limit)].HeaderText = MailAlarmConstants.LimitHeader;
 
-            if (alarmsDataGridView.Columns["IsActive"] != null)
-                alarmsDataGridView.Columns["IsActive"].HeaderText = "Aktif";
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.IsActive)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.IsActive)].HeaderText = MailAlarmConstants.ActiveHeader;
         }
 
         private async void SaveAlarmsButton_Click(object? sender, EventArgs e)
@@ -214,11 +214,11 @@ namespace WinUI.Pages
             try
             {
                 await _mailAlarmService.UpdateAsync(user.Id, activeIds);
-                MessageBox.Show("Alarmlar kaydedildi.", UserConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(MailAlarmConstants.SaveSuccessMessage, UserConstants.InfoTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Alarmlar kaydedilirken hata: {ex.Message}", UserConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(MailAlarmConstants.SaveErrorMessage, ex.Message), UserConstants.ErrorTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix UpdateUserMailAlarmsCommand handler signature to match IRequestHandler contract
- centralize mail alarm strings in MailAlarmConstants and remove magic strings in MailPage

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a57d9b6883248241cfd3817d829b