### PR TITLE
Enable full mail alarm editing

### DIFF
--- a/Application/Features/MailAlarms/Commands/Update/UpdateMailAlarmCommand.cs
+++ b/Application/Features/MailAlarms/Commands/Update/UpdateMailAlarmCommand.cs
@@ -3,4 +3,10 @@ using MediatR;
 
 namespace Application.Features.MailAlarms.Commands.Update;
 
-public record UpdateMailAlarmCommand(int Id, double Limit) : IRequest<MailAlarmDto>;
+public record UpdateMailAlarmCommand(
+    int Id,
+    string Name,
+    string Channel,
+    double Limit,
+    string MailSubject,
+    string MailBody) : IRequest<MailAlarmDto>;

--- a/Application/Features/MailAlarms/Commands/Update/UpdateMailAlarmCommandHandler.cs
+++ b/Application/Features/MailAlarms/Commands/Update/UpdateMailAlarmCommandHandler.cs
@@ -15,7 +15,11 @@ public class UpdateMailAlarmCommandHandler(IMailAlarmRepository repository, IMap
         if (entity == null)
             throw new Exception("Alarm not found");
 
+        entity.Name = request.Name;
+        entity.Channel = request.Channel;
         entity.Limit = request.Limit;
+        entity.MailSubject = request.MailSubject;
+        entity.MailBody = request.MailBody;
         await repository.UpdateAsync(entity);
         return mapper.Map<MailAlarmDto>(entity);
     }

--- a/Application/Features/MailAlarms/Dtos/MailAlarmDto.cs
+++ b/Application/Features/MailAlarms/Dtos/MailAlarmDto.cs
@@ -4,7 +4,10 @@ public class MailAlarmDto
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
     public double Limit { get; set; }
+    public string MailSubject { get; set; } = string.Empty;
+    public string MailBody { get; set; } = string.Empty;
     public bool IsActive { get; set; }
 }
 

--- a/Application/Features/MailAlarms/Queries/GetList/GetMailAlarmsQueryHandler.cs
+++ b/Application/Features/MailAlarms/Queries/GetList/GetMailAlarmsQueryHandler.cs
@@ -17,7 +17,10 @@ public class GetMailAlarmsQueryHandler(
         {
             Id = a.Id,
             Name = a.Name,
+            Channel = a.Channel,
             Limit = a.Limit,
+            MailSubject = a.MailSubject,
+            MailBody = a.MailBody,
             IsActive = activeSet.Contains(a.Id)
         }).ToList();
     }

--- a/WinUI/Forms/EditMailAlarmForm.cs
+++ b/WinUI/Forms/EditMailAlarmForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using WinUI.Constants;
@@ -11,8 +12,11 @@ namespace WinUI.Forms
     {
         private readonly IMailAlarmService _alarmService;
         private readonly MailAlarmDto _alarm;
-        private Label nameLabel = null!;
+        private TextBox nameTextBox = null!;
+        private TextBox channelTextBox = null!;
         private NumericUpDown limitNumericUpDown = null!;
+        private TextBox subjectTextBox = null!;
+        private TextBox bodyTextBox = null!;
         private Button saveButton = null!;
 
         public EditMailAlarmForm(MailAlarmDto alarm)
@@ -20,46 +24,138 @@ namespace WinUI.Forms
             _alarm = alarm;
             _alarmService = Program.Services.GetRequiredService<IMailAlarmService>();
             InitializeComponent();
+            nameTextBox.Text = _alarm.Name;
+            channelTextBox.Text = _alarm.Channel;
+            limitNumericUpDown.Value = (decimal)_alarm.Limit;
+            subjectTextBox.Text = _alarm.MailSubject;
+            bodyTextBox.Text = _alarm.MailBody;
         }
 
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EditMailAlarmForm));
-            nameLabel = new Label();
+            var nameLabel = new Label();
+            var channelLabel = new Label();
+            var limitLabel = new Label();
+            var subjectLabel = new Label();
+            var bodyLabel = new Label();
+            nameTextBox = new TextBox();
+            channelTextBox = new TextBox();
             limitNumericUpDown = new NumericUpDown();
+            subjectTextBox = new TextBox();
+            bodyTextBox = new TextBox();
             saveButton = new Button();
             ((System.ComponentModel.ISupportInitialize)limitNumericUpDown).BeginInit();
             SuspendLayout();
-            // 
+            //
             // nameLabel
-            // 
-            nameLabel.Location = new Point(0, 0);
+            //
+            nameLabel.AutoSize = true;
+            nameLabel.Location = new Point(12, 15);
             nameLabel.Name = "nameLabel";
-            nameLabel.Size = new Size(100, 23);
+            nameLabel.Size = new Size(62, 15);
             nameLabel.TabIndex = 0;
-            // 
+            nameLabel.Text = "Alarm Adı";
+            //
+            // nameTextBox
+            //
+            nameTextBox.Location = new Point(110, 12);
+            nameTextBox.Name = "nameTextBox";
+            nameTextBox.Size = new Size(250, 23);
+            nameTextBox.TabIndex = 1;
+            //
+            // channelLabel
+            //
+            channelLabel.AutoSize = true;
+            channelLabel.Location = new Point(12, 45);
+            channelLabel.Name = "channelLabel";
+            channelLabel.Size = new Size(41, 15);
+            channelLabel.TabIndex = 2;
+            channelLabel.Text = "Kanal";
+            //
+            // channelTextBox
+            //
+            channelTextBox.Location = new Point(110, 42);
+            channelTextBox.Name = "channelTextBox";
+            channelTextBox.Size = new Size(250, 23);
+            channelTextBox.TabIndex = 3;
+            //
+            // limitLabel
+            //
+            limitLabel.AutoSize = true;
+            limitLabel.Location = new Point(12, 75);
+            limitLabel.Name = "limitLabel";
+            limitLabel.Size = new Size(32, 15);
+            limitLabel.TabIndex = 4;
+            limitLabel.Text = "Limit";
+            //
             // limitNumericUpDown
-            // 
-            limitNumericUpDown.Location = new Point(0, 0);
+            //
+            limitNumericUpDown.Location = new Point(110, 72);
             limitNumericUpDown.Name = "limitNumericUpDown";
             limitNumericUpDown.Size = new Size(120, 23);
-            limitNumericUpDown.TabIndex = 1;
-            // 
+            limitNumericUpDown.TabIndex = 5;
+            limitNumericUpDown.Maximum = 1000000;
+            limitNumericUpDown.DecimalPlaces = 2;
+            //
+            // subjectLabel
+            //
+            subjectLabel.AutoSize = true;
+            subjectLabel.Location = new Point(12, 105);
+            subjectLabel.Name = "subjectLabel";
+            subjectLabel.Size = new Size(75, 15);
+            subjectLabel.TabIndex = 6;
+            subjectLabel.Text = "Mail Konusu";
+            //
+            // subjectTextBox
+            //
+            subjectTextBox.Location = new Point(110, 102);
+            subjectTextBox.Name = "subjectTextBox";
+            subjectTextBox.Size = new Size(250, 23);
+            subjectTextBox.TabIndex = 7;
+            //
+            // bodyLabel
+            //
+            bodyLabel.AutoSize = true;
+            bodyLabel.Location = new Point(12, 135);
+            bodyLabel.Name = "bodyLabel";
+            bodyLabel.Size = new Size(67, 15);
+            bodyLabel.TabIndex = 8;
+            bodyLabel.Text = "Mail İçeriği";
+            //
+            // bodyTextBox
+            //
+            bodyTextBox.Location = new Point(110, 132);
+            bodyTextBox.Multiline = true;
+            bodyTextBox.Name = "bodyTextBox";
+            bodyTextBox.Size = new Size(250, 80);
+            bodyTextBox.TabIndex = 9;
+            //
             // saveButton
-            // 
-            saveButton.Location = new Point(0, 0);
+            //
+            saveButton.Location = new Point(285, 220);
             saveButton.Name = "saveButton";
             saveButton.Size = new Size(75, 23);
-            saveButton.TabIndex = 2;
+            saveButton.TabIndex = 10;
+            saveButton.Text = "Kaydet";
+            saveButton.UseVisualStyleBackColor = true;
             saveButton.Click += SaveButton_Click;
-            // 
+            //
             // EditMailAlarmForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(260, 150);
+            ClientSize = new Size(380, 260);
             Controls.Add(nameLabel);
+            Controls.Add(nameTextBox);
+            Controls.Add(channelLabel);
+            Controls.Add(channelTextBox);
+            Controls.Add(limitLabel);
             Controls.Add(limitNumericUpDown);
+            Controls.Add(subjectLabel);
+            Controls.Add(subjectTextBox);
+            Controls.Add(bodyLabel);
+            Controls.Add(bodyTextBox);
             Controls.Add(saveButton);
             Icon = (Icon)resources.GetObject("$this.Icon");
             Name = "EditMailAlarmForm";
@@ -67,14 +163,20 @@ namespace WinUI.Forms
             Text = "Alarm Düzenle";
             ((System.ComponentModel.ISupportInitialize)limitNumericUpDown).EndInit();
             ResumeLayout(false);
+            PerformLayout();
         }
 
         private async void SaveButton_Click(object? sender, EventArgs e)
         {
-            double newLimit = (double)limitNumericUpDown.Value;
+            var command = new UpdateMailAlarmCommand(
+                _alarm.Id,
+                nameTextBox.Text,
+                channelTextBox.Text,
+                (double)limitNumericUpDown.Value,
+                subjectTextBox.Text,
+                bodyTextBox.Text);
             try
             {
-                var command = new UpdateMailAlarmCommand(_alarm.Id, newLimit);
                 var updated = await _alarmService.UpdateAlarmAsync(command);
                 if (updated != null)
                 {

--- a/WinUI/Models/MailAlarmDto.cs
+++ b/WinUI/Models/MailAlarmDto.cs
@@ -4,7 +4,10 @@ public class MailAlarmDto
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
     public double Limit { get; set; }
+    public string MailSubject { get; set; } = string.Empty;
+    public string MailBody { get; set; } = string.Empty;
     public bool IsActive { get; set; }
 }
 

--- a/WinUI/Pages/MailPage.cs
+++ b/WinUI/Pages/MailPage.cs
@@ -201,6 +201,15 @@ namespace WinUI.Pages
             if (alarmsDataGridView.Columns[nameof(MailAlarmDto.IsActive)] != null)
                 alarmsDataGridView.Columns[nameof(MailAlarmDto.IsActive)].HeaderText = MailAlarmConstants.ActiveHeader;
 
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.Channel)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.Channel)].Visible = false;
+
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.MailSubject)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.MailSubject)].Visible = false;
+
+            if (alarmsDataGridView.Columns[nameof(MailAlarmDto.MailBody)] != null)
+                alarmsDataGridView.Columns[nameof(MailAlarmDto.MailBody)].Visible = false;
+
             if (alarmsDataGridView.Columns["Edit"] == null)
             {
                 var editColumn = new DataGridViewImageColumn

--- a/WinUI/Services/MailAlarmService.cs
+++ b/WinUI/Services/MailAlarmService.cs
@@ -30,5 +30,11 @@ public class MailAlarmService(HttpClient httpClient) : IMailAlarmService
     }
 }
 
-public record UpdateMailAlarmCommand(int Id, double Limit);
+public record UpdateMailAlarmCommand(
+    int Id,
+    string Name,
+    string Channel,
+    double Limit,
+    string MailSubject,
+    string MailBody);
 


### PR DESCRIPTION
## Summary
- extend mail alarm DTOs and update command to include channel, subject and body fields
- adjust query handler, service and page to handle new properties and hide extra columns
- redesign EditMailAlarmForm to edit name, channel, limit, subject and body of a mail alarm

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ac2ba44c8324952c376207cacbac