### PR TITLE
Handle disposed pages when showing

### DIFF
--- a/WinUI/Helpers/PageManager.cs
+++ b/WinUI/Helpers/PageManager.cs
@@ -11,14 +11,27 @@ public static class PageManager
 {
     public static void ShowPage(Panel panel, UserControl page)
     {
+        // Ensure the panel exists before attempting any operations on it
         if (panel is null)
             throw new ArgumentNullException(nameof(panel));
 
+        // The page to be displayed must also be provided
         if (page is null)
             throw new ArgumentNullException(nameof(page));
+
+        // Windows Forms controls can be disposed at runtime. Attempting to add a
+        // disposed control to another container results in a NullReferenceException.
+        // Guard against this scenario by throwing a more descriptive exception.
+        if (page.IsDisposed)
+            throw new ObjectDisposedException(page.GetType().Name);
+
+        panel.SuspendLayout();
 
         panel.Controls.Clear();
         page.Dock = DockStyle.Fill;
         panel.Controls.Add(page);
+
+        panel.ResumeLayout();
+        page.BringToFront();
     }
 }


### PR DESCRIPTION
## Summary
- avoid NullReference when showing disposed WinForms pages
- improve layout handling when switching between pages

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b83dcfc083248cf8f02e387c4e98