### PR TITLE
Log warning on alarm emails

### DIFF
--- a/Api/BackgroundServices/MailAlarmWorker.cs
+++ b/Api/BackgroundServices/MailAlarmWorker.cs
@@ -99,7 +99,12 @@ public class MailAlarmWorker(
                     mail.To.Add(item.Email);
 
                     await client.SendMailAsync(mail, stoppingToken);
-                    logger.LogWarning("Alarm {Alarm} triggered for user {Email}. E-mail sent.", item.Alarm.Name, item.Email);
+                    // Warn so the event stands out in the logs since it indicates an abnormal condition
+                    logger.LogWarning(
+                        "Alarm {Alarm} triggered for user {Email} with value {Value}. E-mail sent.",
+                        item.Alarm.Name,
+                        item.Email,
+                        bodyValue);
                     _lastSentTimes[item.UserId] = DateTime.UtcNow;
                 }
             }


### PR DESCRIPTION
## Summary
- Log alarm-triggered emails at Warning level including measured value

## Testing
- `dotnet build` *(fails: command not found; .NET SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ce03227483248f3f6fa4475861ae