### PR TITLE
Send PLC data to SAIS and persist result

### DIFF
--- a/Api/Controllers/SendDataController.cs
+++ b/Api/Controllers/SendDataController.cs
@@ -3,6 +3,7 @@ using Application.Features.SendDatas.Queries.GetById;
 using MediatR;                     
 using Microsoft.AspNetCore.Mvc;
 using Application.Features.SendDatas.Commands;
+using Application.Features.SendDatas.Commands.Create;
 
 namespace Api.Controllers;
 
@@ -26,6 +27,13 @@ public class SendDataController(IMediator mediator) : ControllerBase
         return Ok(result);
     }
     [HttpPost]
+    public async Task<IActionResult> Create(CreateSendDataCommand command)
+    {
+        var result = await mediator.Send(command);
+        return Ok(result);
+    }
+
+    [HttpPost("send")]
     public async Task<IActionResult> Send(SendDataCommand command)
     {
         var result = await mediator.Send(command);

--- a/Application/Features/SendDatas/Commands/Create/CreateSendDataCommand.cs
+++ b/Application/Features/SendDatas/Commands/Create/CreateSendDataCommand.cs
@@ -1,0 +1,37 @@
+using Application.Features.SendDatas.Dtos;
+using MediatR;
+using System;
+
+namespace Application.Features.SendDatas.Commands.Create;
+
+public class CreateSendDataCommand : IRequest<SendDataDto>
+{
+    public Guid Stationid { get; set; }
+    public DateTime Readtime { get; set; }
+    public string SoftwareVersion { get; set; } = string.Empty;
+    public double AkisHizi { get; set; }
+    public double AKM { get; set; }
+    public double CozunmusOksijen { get; set; }
+    public double Debi { get; set; }
+    public double? DesarjDebi { get; set; }
+    public double? HariciDebi { get; set; }
+    public double? HariciDebi2 { get; set; }
+    public double KOi { get; set; }
+    public double pH { get; set; }
+    public double Sicaklik { get; set; }
+    public double Iletkenlik { get; set; }
+    public int Period { get; set; }
+    public int AkisHizi_Status { get; set; }
+    public int AKM_Status { get; set; }
+    public int CozunmusOksijen_Status { get; set; }
+    public int Debi_Status { get; set; }
+    public int? DesarjDebi_Status { get; set; }
+    public int? HariciDebi_Status { get; set; }
+    public int? HariciDebi2_Status { get; set; }
+    public int KOi_Status { get; set; }
+    public int pH_Status { get; set; }
+    public int Sicaklik_Status { get; set; }
+    public string Iletkenlik_Status { get; set; } = string.Empty;
+    public bool? IsSent { get; set; }
+}
+

--- a/Application/Features/SendDatas/Commands/Create/CreateSendDataCommandHandler.cs
+++ b/Application/Features/SendDatas/Commands/Create/CreateSendDataCommandHandler.cs
@@ -1,0 +1,52 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Features.SendDatas.Dtos;
+using AutoMapper;
+using Domain.Entities;
+using Domain.Repositories;
+using MediatR;
+
+namespace Application.Features.SendDatas.Commands.Create;
+
+public class CreateSendDataCommandHandler(
+    ISendDataRepository repository,
+    IMapper mapper
+) : IRequestHandler<CreateSendDataCommand, SendDataDto>
+{
+    public async Task<SendDataDto> Handle(CreateSendDataCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new SendData
+        {
+            Stationid = request.Stationid,
+            Readtime = request.Readtime,
+            SoftwareVersion = request.SoftwareVersion,
+            AkisHizi = request.AkisHizi,
+            AKM = request.AKM,
+            CozunmusOksijen = request.CozunmusOksijen,
+            Debi = request.Debi,
+            DesarjDebi = request.DesarjDebi,
+            HariciDebi = request.HariciDebi,
+            HariciDebi2 = request.HariciDebi2,
+            KOi = request.KOi,
+            pH = request.pH,
+            Sicaklik = request.Sicaklik,
+            Iletkenlik = request.Iletkenlik,
+            Period = request.Period,
+            AkisHizi_Status = request.AkisHizi_Status,
+            AKM_Status = request.AKM_Status,
+            CozunmusOksijen_Status = request.CozunmusOksijen_Status,
+            Debi_Status = request.Debi_Status,
+            DesarjDebi_Status = request.DesarjDebi_Status,
+            HariciDebi_Status = request.HariciDebi_Status,
+            HariciDebi2_Status = request.HariciDebi2_Status,
+            KOi_Status = request.KOi_Status,
+            pH_Status = request.pH_Status,
+            Sicaklik_Status = request.Sicaklik_Status,
+            Iletkenlik_Status = request.Iletkenlik_Status,
+            IsSent = request.IsSent
+        };
+
+        await repository.AddAsync(entity);
+        return mapper.Map<SendDataDto>(entity);
+    }
+}

--- a/Application/Features/SendDatas/Profiles/SendDataProfile.cs
+++ b/Application/Features/SendDatas/Profiles/SendDataProfile.cs
@@ -9,5 +9,6 @@ public class SendDataProfile : Profile
     public SendDataProfile()
     {
         CreateMap<SendData, SendDataDto>();
+        CreateMap<Commands.Create.CreateSendDataCommand, SendData>();
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -258,6 +258,23 @@ namespace WinUI
                         return handler;
                     });
 
+                    services.AddHttpClient<ISendDataService, SendDataService>(client =>
+                    {
+                        string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";
+                        baseUrl = baseUrl.TrimEnd('/');
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+                        }
+                        return handler;
+                    }).AddStandardResilienceHandler(options =>
+                        options.Retry.MaxRetryAttempts = 3);
+
                     services.AddSingleton<IDatabaseSearchEngine, SqlDatabaseSearchEngine>();
                     services.AddSingleton<IDatabaseSelectionService, DatabaseSelectionService>();
                     services.AddHostedService<TicketRefreshService>();

--- a/WinUI/Services/SendDataService.cs
+++ b/WinUI/Services/SendDataService.cs
@@ -1,0 +1,19 @@
+using System.Net.Http.Json;
+using Domain.Entities;
+using WinUI.Constants;
+
+namespace WinUI.Services;
+
+public interface ISendDataService
+{
+    Task CreateAsync(SendData data);
+}
+
+public class SendDataService(HttpClient httpClient) : ISendDataService
+{
+    public async Task CreateAsync(SendData data)
+    {
+        using var response = await httpClient.PostAsJsonAsync(SendDataConstants.ApiUrl, data);
+        response.EnsureSuccessStatusCode();
+    }
+}


### PR DESCRIPTION
## Summary
- send PLC readings to configured SAIS endpoint and log when API info missing
- record SAIS response in local database with `IsSent` flag
- expose API endpoint and handler for storing send data
- map station status from digital sensor inputs and include in API payload and stored data

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c818c900dc83249fec01ac03d2f714