### PR TITLE
Handle PLC configuration and access status on home page

### DIFF
--- a/WinUI/Helpers/StateColors.cs
+++ b/WinUI/Helpers/StateColors.cs
@@ -21,4 +21,14 @@ public static class StateColors
     /// Color used when an error occurs while retrieving PLC data.
     /// </summary>
     public static readonly Color Error = Color.FromArgb(235, 85, 101);
+
+    /// <summary>
+    /// Color used when PLC configuration is missing either in the database or settings.
+    /// </summary>
+    public static readonly Color NotConfigured = Color.FromArgb(204, 153, 0);
+
+    /// <summary>
+    /// Color used when PLC is configured but cannot be reached.
+    /// </summary>
+    public static readonly Color NoAccess = Color.FromArgb(220, 53, 69);
 }

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -52,6 +52,17 @@ namespace WinUI.Pages
             {
                 TimerAssignUI_Tick(this, EventArgs.Empty);
             }
+            else
+            {
+                digitalSensorBar1.SystemStateDescription = "KURULMADI";
+                digitalSensorBar1.SystemStateDescriptionColor = StateColors.NotConfigured;
+                digitalSensorBar1.SystemStateTitleColor = StateColors.NotConfigured;
+                digitalSensorBar1.DataStateDescription = "KURULMADI";
+                digitalSensorBar1.DataStateDescriptionColor = StateColors.NotConfigured;
+                StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Kurulmadı";
+                _isConnected = false;
+                Log.Warning("PLC yapılandırması eksik: IP adresi tanımlı değil");
+            }
         }
 
         public Task<PlcDataDto?> ReadPlcDataAsync()
@@ -157,9 +168,12 @@ namespace WinUI.Pages
                     sensor.SensorState = StateColors.Waiting;
 
                 digitalSensorBar1.SystemStateDescription = "KURULMADI";
-                digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
+                digitalSensorBar1.SystemStateDescriptionColor = StateColors.NotConfigured;
+                digitalSensorBar1.SystemStateTitleColor = StateColors.NotConfigured;
+                digitalSensorBar1.DataStateDescription = "KURULMADI";
+                digitalSensorBar1.DataStateDescriptionColor = StateColors.NotConfigured;
 
-                StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
+                StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Kurulmadı";
                 _isConnected = false;
                 Log.Warning("PLC bilgileri henüz kurulmadı");
             }
@@ -170,12 +184,13 @@ namespace WinUI.Pages
                 foreach (var sensor in _digitalSensors)
                     sensor.SensorState = _lastConnectedTime.HasValue ? StateColors.Error : StateColors.Waiting;
 
-                digitalSensorBar1.SystemStateDescription = "KOPUK";
-                digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
+                digitalSensorBar1.SystemStateDescription = "ERİŞİM YOK";
+                digitalSensorBar1.SystemStateDescriptionColor = StateColors.NoAccess;
+                digitalSensorBar1.SystemStateTitleColor = StateColors.NoAccess;
 
                 digitalSensorBar1.DataStateDescription = "HATA";
-                digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
-                StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
+                digitalSensorBar1.DataStateDescriptionColor = StateColors.NoAccess;
+                StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Erişim Yok";
                 _isConnected = false;
                 Log.Error(ex, "API erişim hatası");
             }
@@ -188,6 +203,7 @@ namespace WinUI.Pages
 
                 digitalSensorBar1.SystemStateDescription = "KOPUK";
                 digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
+                digitalSensorBar1.SystemStateTitleColor = StateColors.Error;
 
                 digitalSensorBar1.DataStateDescription = "HATA";
                 digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;


### PR DESCRIPTION
## Summary
- add dedicated colors for PLC configuration and access error states
- display "KURULMADI" with dark yellow styling when PLC settings are missing locally or in the API
- surface "ERİŞİM YOK" with red styling when the PLC endpoint cannot be reached

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c71e3cc8324a69e38624e6fb11e