### PR TITLE
Show SAIS API connectivity on home page

### DIFF
--- a/WinUI/Helpers/StateColors.cs
+++ b/WinUI/Helpers/StateColors.cs
@@ -18,6 +18,11 @@ public static class StateColors
     public static readonly Color Ok = Color.FromArgb(19, 162, 97);
 
     /// <summary>
+    /// Color used when a configuration is missing or attention is required.
+    /// </summary>
+    public static readonly Color Warning = Color.FromArgb(204, 153, 0);
+
+    /// <summary>
     /// Color used when an error occurs while retrieving PLC data.
     /// </summary>
     public static readonly Color Error = Color.FromArgb(235, 85, 101);

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -11,15 +11,20 @@ namespace WinUI.Pages
     public partial class HomePage : UserControl
     {
         private readonly IPlcDataService _plcService;
+        private readonly IApiEndpointService _apiEndpointService;
+        private readonly ITicketService _ticketService;
         private readonly List<ChannelControl> _channels;
         private readonly List<DigitalSensorControl> _digitalSensors;
         private DateTime? _lastConnectedTime;
         private bool _isConnected;
+        private ApiConnectionStatus _apiConnectionStatus = ApiConnectionStatus.Unknown;
 
-        public HomePage(IPlcDataService plcService)
+        public HomePage(IPlcDataService plcService, IApiEndpointService apiEndpointService, ITicketService ticketService)
         {
             InitializeComponent();
             _plcService = plcService;
+            _apiEndpointService = apiEndpointService;
+            _ticketService = ticketService;
             _channels = new()
             {
                 ChannelAkm,
@@ -59,6 +64,124 @@ namespace WinUI.Pages
             return _plcService.GetLatestAsync();
         }
 
+        private async Task<ApiConnectionStatus> UpdateSaisConnectionStatusAsync()
+        {
+            try
+            {
+                var endpoint = await _apiEndpointService.GetFirstAsync();
+                if (endpoint == null)
+                {
+                    ApplyApiConnectionStatus(ApiConnectionStatus.NotConfigured);
+                    return ApiConnectionStatus.NotConfigured;
+                }
+
+                try
+                {
+                    await _ticketService.EnsureTicketAsync();
+                }
+                catch (HttpRequestException ex)
+                {
+                    if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                    {
+                        Log.Warning(ex, "SAIS ticket alınamadı.");
+                    }
+                    ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                    return ApiConnectionStatus.NoAccess;
+                }
+                catch (TaskCanceledException ex)
+                {
+                    if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                    {
+                        Log.Warning(ex, "SAIS ticket isteği zaman aşımına uğradı.");
+                    }
+                    ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                    return ApiConnectionStatus.NoAccess;
+                }
+                catch (Exception ex)
+                {
+                    if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                    {
+                        Log.Error(ex, "SAIS ticket alınırken beklenmeyen bir hata oluştu.");
+                    }
+                    ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                    return ApiConnectionStatus.NoAccess;
+                }
+
+                if (!string.IsNullOrWhiteSpace(StationConstants.Ticket) &&
+                    DateTime.Now < StationConstants.TicketExpiry)
+                {
+                    ApplyApiConnectionStatus(ApiConnectionStatus.Connected);
+                    return ApiConnectionStatus.Connected;
+                }
+
+                ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                return ApiConnectionStatus.NoAccess;
+            }
+            catch (HttpRequestException ex)
+            {
+                if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                {
+                    Log.Warning(ex, "SAIS API ayarları alınamadı.");
+                }
+                ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                return ApiConnectionStatus.NoAccess;
+            }
+            catch (TaskCanceledException ex)
+            {
+                if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                {
+                    Log.Warning(ex, "SAIS API ayarları isteği zaman aşımına uğradı.");
+                }
+                ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                return ApiConnectionStatus.NoAccess;
+            }
+            catch (Exception ex)
+            {
+                if (_apiConnectionStatus != ApiConnectionStatus.NoAccess)
+                {
+                    Log.Error(ex, "SAIS API ayarları alınırken beklenmeyen bir hata oluştu.");
+                }
+                ApplyApiConnectionStatus(ApiConnectionStatus.NoAccess);
+                return ApiConnectionStatus.NoAccess;
+            }
+        }
+
+        private void ApplyApiConnectionStatus(ApiConnectionStatus status)
+        {
+            if (_apiConnectionStatus == status)
+            {
+                return;
+            }
+
+            _apiConnectionStatus = status;
+            switch (status)
+            {
+                case ApiConnectionStatus.Connected:
+                    digitalSensorBar1.DataStateDescription = "BAĞLI";
+                    digitalSensorBar1.DataStateDescriptionColor = StateColors.Ok;
+                    Log.Information("SAIS API bağlantısı sağlandı.");
+                    break;
+                case ApiConnectionStatus.NotConfigured:
+                    digitalSensorBar1.DataStateDescription = "KURULMADI";
+                    digitalSensorBar1.DataStateDescriptionColor = StateColors.Warning;
+                    Log.Warning("SAIS API ayarları bulunamadı.");
+                    break;
+                default:
+                    digitalSensorBar1.DataStateDescription = "ERİŞİM YOK";
+                    digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
+                    Log.Warning("SAIS API erişimi sağlanamadı.");
+                    break;
+            }
+        }
+
+        private enum ApiConnectionStatus
+        {
+            Unknown,
+            Connected,
+            NoAccess,
+            NotConfigured
+        }
+
         private static bool IsPlcConfigured()
         {
             try
@@ -83,21 +206,14 @@ namespace WinUI.Pages
         {
             try
             {
-                if (string.IsNullOrEmpty(StationConstants.Ticket) ||
-                    DateTime.Now >= StationConstants.TicketExpiry)
+                var apiStatus = await UpdateSaisConnectionStatusAsync();
+
+                if (apiStatus != ApiConnectionStatus.Connected)
                 {
-                    digitalSensorBar1.DataStateDescription = "GÖNDERMİYOR";
-                    digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
                     digitalSensorBar1.SystemStateDescription = "KOPUK";
                     digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
                     StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
                     _isConnected = false;
-                    Log.Warning("Ticket yok veya süresi doldu");
-                }
-                else
-                {
-                    digitalSensorBar1.DataStateDescription = "GÖNDERİYOR";
-                    digitalSensorBar1.DataStateDescriptionColor = StateColors.Ok;
                 }
 
                 var value = await ReadPlcDataAsync();
@@ -173,8 +289,6 @@ namespace WinUI.Pages
                 digitalSensorBar1.SystemStateDescription = "KOPUK";
                 digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
 
-                digitalSensorBar1.DataStateDescription = "HATA";
-                digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
                 _isConnected = false;
                 Log.Error(ex, "API erişim hatası");
@@ -189,8 +303,6 @@ namespace WinUI.Pages
                 digitalSensorBar1.SystemStateDescription = "KOPUK";
                 digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
 
-                digitalSensorBar1.DataStateDescription = "HATA";
-                digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
                 _isConnected = false;
                 Log.Error(ex, "PLC verisi okunamadı");


### PR DESCRIPTION
## Summary
- inject the API endpoint and ticket services into the home page and poll the SAIS API connection state
- surface "BAĞLI", "ERİŞİM YOK" or "KURULMADI" in the data status indicator based on ticket validity and API availability
- add a shared warning color for the new dark yellow state indicator

## Testing
- dotnet build ISKI.SAIS.MarbinYS.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94ccf11a083249bcaf0bc58602cef