### PR TITLE
Refactor log messages into constants

### DIFF
--- a/Api/BackgroundServices/MailAlarmWorker.cs
+++ b/Api/BackgroundServices/MailAlarmWorker.cs
@@ -1,4 +1,5 @@
 using System;
+using Api.Constants;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -102,7 +103,7 @@ public class MailAlarmWorker(
                     await client.SendMailAsync(mail, stoppingToken);
                     // Warn so the event stands out in the logs since it indicates an abnormal condition
                     logger.LogWarning(
-                        "Alarm {Alarm} triggered for user {Email} with value {Value}. E-mail sent.",
+                        LogMessages.MailAlarmWorker.AlarmTriggered,
                         item.Alarm.Name,
                         item.Email,
                         bodyValue);
@@ -111,7 +112,7 @@ public class MailAlarmWorker(
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error while processing mail alarms");
+                logger.LogError(ex, LogMessages.MailAlarmWorker.ProcessingError);
             }
 
             await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), stoppingToken);

--- a/Api/BackgroundServices/PlcDataWorker.cs
+++ b/Api/BackgroundServices/PlcDataWorker.cs
@@ -1,4 +1,5 @@
 using System;
+using Api.Constants;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,7 +44,7 @@ public class PlcDataWorker(
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error while reading PLC data");
+                logger.LogError(ex, LogMessages.PlcDataWorker.ReadError);
             }
             await Task.Delay(TimeSpan.FromSeconds(interval), stoppingToken);
         }

--- a/Api/Constants/LogMessages.cs
+++ b/Api/Constants/LogMessages.cs
@@ -1,0 +1,28 @@
+namespace Api.Constants;
+
+public static class LogMessages
+{
+    public static class Program
+    {
+        public const string ConnectionStringEmpty = "Connection string is empty";
+        public const string DatabaseChecked = "Database checked";
+        public const string DatabaseInitializationFailed = "Database initialization failed";
+        public const string ApiStarted = "API started";
+    }
+
+    public static class MailAlarmWorker
+    {
+        public const string AlarmTriggered = "Alarm {Alarm} triggered for user {Email} with value {Value}. E-mail sent.";
+        public const string ProcessingError = "Error while processing mail alarms";
+    }
+
+    public static class PlcDataWorker
+    {
+        public const string ReadError = "Error while reading PLC data";
+    }
+
+    public static class PlcDataController
+    {
+        public const string CacheEmpty = "PLC data requested but cache is empty";
+    }
+}

--- a/Api/Controllers/PlcDataController.cs
+++ b/Api/Controllers/PlcDataController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Infrastructure.Services.PLC;
 using Application.Features.PlcData.Dtos;
+using Api.Constants;
 using AutoMapper;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +17,7 @@ public class PlcDataController(IPlcDataCache dataCache, IMapper mapper, ILogger<
         var data = dataCache.GetLatest();
         if (data == null)
         {
-            logger.LogWarning("PLC data requested but cache is empty");
+            logger.LogWarning(LogMessages.PlcDataController.CacheEmpty);
             return NotFound();
         }
 

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Api.BackgroundServices;
+using Api.Constants;
 using Application;
 using Infrastructure;
 using Infrastructure.Persistence;
@@ -14,7 +15,7 @@ builder.Host.UseSerilog((ctx, lc) => lc.ReadFrom.Configuration(ctx.Configuration
 builder.Services.AddApplication();
 var conn = builder.Configuration.GetConnectionString("Default") ?? string.Empty;
 if (string.IsNullOrWhiteSpace(conn))
-    Log.Warning("Connection string is empty");
+    Log.Warning(LogMessages.Program.ConnectionStringEmpty);
 builder.Services.AddInfrastructure(conn);
 
 builder.Services.AddControllers();
@@ -31,11 +32,11 @@ using (var scope = app.Services.CreateScope())
     {
         var context = scope.ServiceProvider.GetRequiredService<IBKSContext>();
         context.Database.EnsureCreated();
-        Log.Information("Database checked");
+        Log.Information(LogMessages.Program.DatabaseChecked);
     }
     catch (Exception ex)
     {
-        Log.Error(ex, "Database initialization failed");
+        Log.Error(ex, LogMessages.Program.DatabaseInitializationFailed);
     }
 }
 
@@ -51,5 +52,5 @@ app.UseGlobalExceptionHandling();
 
 app.MapControllers();
 
-Log.Information("API started");
+Log.Information(LogMessages.Program.ApiStarted);
 app.Run();

--- a/Application/Constants/LogMessages.cs
+++ b/Application/Constants/LogMessages.cs
@@ -1,0 +1,17 @@
+namespace Application.Constants;
+
+public static class LogMessages
+{
+    public static class PlcData
+    {
+        public const string ReadOrSaveError = "Error reading or saving PLC data";
+    }
+
+    public static class Stations
+    {
+        public const string CreatedSuccessfully = "Station {StationId} created successfully";
+        public const string CreationError = "Error creating station {StationId}";
+        public const string UpdatedSuccessfully = "Station {StationId} updated successfully";
+        public const string UpdateError = "Error updating station {StationId}";
+    }
+}

--- a/Application/Features/PlcData/Commands/ReadAndSavePlcData/ReadAndSavePlcDataCommandHandler.cs
+++ b/Application/Features/PlcData/Commands/ReadAndSavePlcData/ReadAndSavePlcDataCommandHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Application.Constants;
 using Application.Services.PlcData;
 using Infrastructure.Persistence;
 using MediatR;
@@ -60,7 +61,7 @@ public class ReadAndSavePlcDataCommandHandler(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error reading or saving PLC data");
+            logger.LogError(ex, LogMessages.PlcData.ReadOrSaveError);
             throw;
         }
     }

--- a/Application/Features/Stations/Commands/Create/CreateStationCommandHandler.cs
+++ b/Application/Features/Stations/Commands/Create/CreateStationCommandHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using Application.Constants;
 using Application.Features.Stations.Dtos;
 using AutoMapper;
 using Domain.Entities;
@@ -20,13 +21,13 @@ public class CreateStationCommandHandler(
             var entity = mapper.Map<Station>(request);
             entity = await repository.AddAsync(entity);
 
-            Log.Information("Station {StationId} created successfully", entity.StationId);
+            Log.Information(LogMessages.Stations.CreatedSuccessfully, entity.StationId);
 
             return mapper.Map<StationDto>(entity);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error creating station {StationId}", request.StationId);
+            Log.Error(ex, LogMessages.Stations.CreationError, request.StationId);
 
             throw;
         }

--- a/Application/Features/Stations/Commands/Update/UpdateStationCommandHandler.cs
+++ b/Application/Features/Stations/Commands/Update/UpdateStationCommandHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using Application.Constants;
 using Application.Features.Stations.Dtos;
 using AutoMapper;
 using Domain.Entities;
@@ -24,13 +25,13 @@ public class UpdateStationCommandHandler(
             mapper.Map(request, entity);
             entity = await repository.UpdateAsync(entity);
 
-            Log.Information("Station {StationId} updated successfully", entity.StationId);
+            Log.Information(LogMessages.Stations.UpdatedSuccessfully, entity.StationId);
 
             return mapper.Map<StationDto>(entity);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error updating station {StationId}", request.StationId);
+            Log.Error(ex, LogMessages.Stations.UpdateError, request.StationId);
 
             throw;
         }

--- a/ISKI.Core/Constants/LogMessages.cs
+++ b/ISKI.Core/Constants/LogMessages.cs
@@ -1,0 +1,9 @@
+namespace ISKI.Core.Constants;
+
+public static class LogMessages
+{
+    public static class ExceptionMiddleware
+    {
+        public const string BusinessRuleViolation = "İş kuralı ihlali";
+    }
+}

--- a/ISKI.Core/CrossCuttingConcerns/Exceptions/ExceptionHandling/ExceptionMiddleware.cs
+++ b/ISKI.Core/CrossCuttingConcerns/Exceptions/ExceptionHandling/ExceptionMiddleware.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Data.SqlClient;
+using ISKI.Core.Constants;
 
 namespace ISKI.Core.CrossCuttingConcerns.Exceptions.ExceptionHandling;
 
@@ -21,7 +22,7 @@ public class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddlewa
         }
         catch (BusinessException bx)
         {
-            _logger.LogWarning(bx, "İş kuralı ihlali");
+            _logger.LogWarning(bx, LogMessages.ExceptionMiddleware.BusinessRuleViolation);
             context.Response.StatusCode = 400;
             await WriteErrorResponse(context, bx.Message);
         }

--- a/Infrastructure/Constants/LogMessages.cs
+++ b/Infrastructure/Constants/LogMessages.cs
@@ -1,0 +1,10 @@
+namespace Infrastructure.Constants;
+
+public static class LogMessages
+{
+    public static class PlcDataCache
+    {
+        public const string NullDataAttempt = "Attempted to cache null PLC data";
+        public const string CacheUpdated = "PLC data cache updated at {Time}";
+    }
+}

--- a/Infrastructure/Services/PLC/PlcDataCache.cs
+++ b/Infrastructure/Services/PLC/PlcDataCache.cs
@@ -1,5 +1,6 @@
 using System;
 using Domain.Entities;
+using Infrastructure.Constants;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Services.PLC;
@@ -30,14 +31,14 @@ public class PlcDataCache : IPlcDataCache
     {
         if (data == null)
         {
-            _logger.LogWarning("Attempted to cache null PLC data");
+            _logger.LogWarning(LogMessages.PlcDataCache.NullDataAttempt);
             return;
         }
 
         lock (_lock)
         {
             _current = data;
-            _logger.LogInformation("PLC data cache updated at {Time}", DateTime.UtcNow);
+            _logger.LogInformation(LogMessages.PlcDataCache.CacheUpdated, DateTime.UtcNow);
         }
     }
 }

--- a/WinUI/Constants/LogMessages.cs
+++ b/WinUI/Constants/LogMessages.cs
@@ -3,4 +3,52 @@ namespace WinUI.Constants;
 public static class LogMessages
 {
     public const string SaisApiNotConfigured = "SAIS API kurulumu yapılmamış.";
+
+    public static class TicketService
+    {
+        public const string TicketMissingOrExpired = "SAIS ticket missing or expired. Refreshing ticket.";
+    }
+
+    public static class SaisApiService
+    {
+        public const string SessionNotFoundOrExpired = "SAIS session not found or expired. Refreshing ticket and retrying.";
+    }
+
+    public static class DatabaseSelectionService
+    {
+        public const string SettingsSaved = "Database settings saved for server {Server}";
+        public const string ApiConfigurationUpdateFailed = "Failed to update API configuration";
+    }
+
+    public static class PlcDataSendService
+    {
+        public const string UnexpectedError = "SAIS veri gönderimi sırasında beklenmeyen hata oluştu.";
+        public const string StationInfoNotFound = "İstasyon bilgisi bulunamadı.";
+        public const string PlcInfoNotFound = "PLC bilgileri bulunamadı.";
+        public const string PlcDataUnavailable = "PLC verisi alınamadı.";
+        public const string SendDataFailed = "SAIS SendData failed: {Message}";
+        public const string UnknownError = "Unknown error";
+        public const string SendDataRequestFailed = "SAIS SendData isteği tamamlanamadı.";
+    }
+
+    public static class PlcDataService
+    {
+        public const string PlcInfoNotFound = "PLC bilgileri bulunamadı";
+        public const string PlcApiError = "PLC API hatası {StatusCode}: {Error}";
+    }
+
+    public static class HomePage
+    {
+        public const string PlcConfigurationMissing = "PLC yapılandırması eksik: IP adresi tanımlı değil";
+        public const string TicketMissingOrExpired = "Ticket yok veya süresi doldu";
+        public const string PlcDataRead = "PLC verisi okundu";
+        public const string PlcInfoNotYetConfigured = "PLC bilgileri henüz kurulmadı";
+        public const string ApiAccessError = "API erişim hatası";
+        public const string PlcDataReadFailed = "PLC verisi okunamadı";
+    }
+
+    public static class Program
+    {
+        public const string ApplicationStarted = "WinUI started";
+    }
 }

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -61,7 +61,7 @@ namespace WinUI.Pages
                 digitalSensorBar1.DataStateDescriptionColor = StateColors.NotConfigured;
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Kurulmadı";
                 _isConnected = false;
-                Log.Warning("PLC yapılandırması eksik: IP adresi tanımlı değil");
+                Log.Warning(LogMessages.HomePage.PlcConfigurationMissing);
             }
         }
 
@@ -103,7 +103,7 @@ namespace WinUI.Pages
                     digitalSensorBar1.SystemStateDescriptionColor = StateColors.Error;
                     StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
                     _isConnected = false;
-                    Log.Warning("Ticket yok veya süresi doldu");
+                    Log.Warning(LogMessages.HomePage.TicketMissingOrExpired);
                 }
                 else
                 {
@@ -158,7 +158,7 @@ namespace WinUI.Pages
                     var elapsed = DateTime.Now - _lastConnectedTime.Value;
                     StatusBarControl.ConnectionTime = $"Bağlantı Zamanı: {elapsed:hh\\:mm\\:ss}";
                 }
-                Log.Information("PLC verisi okundu");
+                Log.Information(LogMessages.HomePage.PlcDataRead);
             }
             catch (InvalidOperationException)
             {
@@ -175,7 +175,7 @@ namespace WinUI.Pages
 
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Kurulmadı";
                 _isConnected = false;
-                Log.Warning("PLC bilgileri henüz kurulmadı");
+                Log.Warning(LogMessages.HomePage.PlcInfoNotYetConfigured);
             }
             catch (HttpRequestException ex)
             {
@@ -192,7 +192,7 @@ namespace WinUI.Pages
                 digitalSensorBar1.DataStateDescriptionColor = StateColors.NoAccess;
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Erişim Yok";
                 _isConnected = false;
-                Log.Error(ex, "API erişim hatası");
+                Log.Error(ex, LogMessages.HomePage.ApiAccessError);
             }
             catch (Exception ex)
             {
@@ -209,7 +209,7 @@ namespace WinUI.Pages
                 digitalSensorBar1.DataStateDescriptionColor = StateColors.Error;
                 StatusBarControl.ConnectionStatement = "Bağlantı Durumu: Bağlı Değil";
                 _isConnected = false;
-                Log.Error(ex, "PLC verisi okunamadı");
+                Log.Error(ex, LogMessages.HomePage.PlcDataReadFailed);
             }
         }
     }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -4,6 +4,7 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer;
 using System.Text.Json.Nodes;
+using WinUI.Constants;
 using WinUI.Forms;
 using WinUI.Pages;
 using WinUI.Services;
@@ -27,7 +28,7 @@ namespace WinUI
             splashThread.Start();
 
             var host = CreateHostBuilder(args).Build();
-            Log.Information("WinUI started");
+            Log.Information(LogMessages.Program.ApplicationStarted);
             Services = host.Services;
             using var scope = Services.CreateScope();
             var services = scope.ServiceProvider;

--- a/WinUI/Services/DatabaseSelectionService.cs
+++ b/WinUI/Services/DatabaseSelectionService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Serilog;
+using WinUI.Constants;
 using WinUI.Models;
 
 namespace WinUI.Services;
@@ -81,11 +82,11 @@ public class DatabaseSelectionService : IDatabaseSelectionService
                 await File.WriteAllTextAsync(_apiSettingsPath,
                     root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
             }
-            Log.Information("Database settings saved for server {Server}", settings.Server);
+            Log.Information(LogMessages.DatabaseSelectionService.SettingsSaved, settings.Server);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Failed to update API configuration");
+            Log.Error(ex, LogMessages.DatabaseSelectionService.ApiConfigurationUpdateFailed);
         }
     }
 

--- a/WinUI/Services/PlcDataSendService.cs
+++ b/WinUI/Services/PlcDataSendService.cs
@@ -57,7 +57,7 @@ public class PlcDataSendService : BackgroundService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "SAIS veri gönderimi sırasında beklenmeyen hata oluştu.");
+                _logger.LogError(ex, LogMessages.PlcDataSendService.UnexpectedError);
             }
 
             try
@@ -76,7 +76,7 @@ public class PlcDataSendService : BackgroundService
         var station = await _stationService.GetFirstAsync();
         if (station == null)
         {
-            _logger.LogWarning("İstasyon bilgisi bulunamadı.");
+            _logger.LogWarning(LogMessages.PlcDataSendService.StationInfoNotFound);
             return;
         }
 
@@ -87,13 +87,13 @@ public class PlcDataSendService : BackgroundService
         }
         catch (InvalidOperationException ex) when (string.Equals(ex.Message, "PLC_NOT_CONFIGURED", StringComparison.OrdinalIgnoreCase))
         {
-            _logger.LogWarning("PLC bilgileri bulunamadı.");
+            _logger.LogWarning(LogMessages.PlcDataSendService.PlcInfoNotFound);
             return;
         }
 
         if (plcData == null)
         {
-            _logger.LogWarning("PLC verisi alınamadı.");
+            _logger.LogWarning(LogMessages.PlcDataSendService.PlcDataUnavailable);
             return;
         }
 
@@ -121,12 +121,12 @@ public class PlcDataSendService : BackgroundService
                 return true;
             }
 
-            _logger.LogWarning("SAIS SendData failed: {Message}", result?.message ?? "Unknown error");
+            _logger.LogWarning(LogMessages.PlcDataSendService.SendDataFailed, result?.message ?? LogMessages.PlcDataSendService.UnknownError);
             return false;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "SAIS SendData isteği tamamlanamadı.");
+            _logger.LogError(ex, LogMessages.PlcDataSendService.SendDataRequestFailed);
             return false;
         }
     }

--- a/WinUI/Services/PlcDataService.cs
+++ b/WinUI/Services/PlcDataService.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Serilog;
+using WinUI.Constants;
 using WinUI.Models;
 
 namespace WinUI.Services;
@@ -24,14 +25,14 @@ public class PlcDataService : IPlcDataService
         using var response = await _httpClient.GetAsync("api/plcdata");
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            Log.Warning("PLC bilgileri bulunamadı");
+            Log.Warning(LogMessages.PlcDataService.PlcInfoNotFound);
             throw new InvalidOperationException("PLC_NOT_CONFIGURED");
         }
 
         if (!response.IsSuccessStatusCode)
         {
             var error = await response.Content.ReadAsStringAsync();
-            Log.Error("PLC API hatası {StatusCode}: {Error}", response.StatusCode, error);
+            Log.Error(LogMessages.PlcDataService.PlcApiError, response.StatusCode, error);
             throw new HttpRequestException("PLC API request failed");
         }
 

--- a/WinUI/Services/SaisApiService.cs
+++ b/WinUI/Services/SaisApiService.cs
@@ -74,7 +74,7 @@ public class SaisApiService : ISaisApiService
         HttpResponseMessage response = await sendRequest(baseUrl);
         if (response.StatusCode == HttpStatusCode.Unauthorized)
         {
-            _logger.LogWarning("SAIS session not found or expired. Refreshing ticket and retrying.");
+            _logger.LogWarning(LogMessages.SaisApiService.SessionNotFoundOrExpired);
             response.Dispose();
             await _ticketService.RefreshTicketAsync();
             baseUrl = await PrepareAsync();

--- a/WinUI/Services/TicketService.cs
+++ b/WinUI/Services/TicketService.cs
@@ -25,7 +25,7 @@ public class TicketService(HttpClient httpClient, IApiEndpointService apiEndpoin
             return;
         }
 
-        logger.LogWarning("SAIS ticket missing or expired. Refreshing ticket.");
+        logger.LogWarning(LogMessages.TicketService.TicketMissingOrExpired);
         await RefreshTicketAsync();
     }
 


### PR DESCRIPTION
## Summary
- centralize log message strings into dedicated constant classes across the API, application, infrastructure, core, and WinUI layers
- refactor existing logging calls to reference the new constants and eliminate magic strings

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94f39e18c83248363b7c4463772e0