### PR TITLE
Fix page switching to avoid double clearing

### DIFF
--- a/WinUI/Helpers/PageManager.cs
+++ b/WinUI/Helpers/PageManager.cs
@@ -1,12 +1,42 @@
-﻿namespace WinUI.Helpers;
+using System;
+using System.Windows.Forms;
+
+namespace WinUI.Helpers;
 
 public static class PageManager
 {
     public static void ShowPage(Panel panel, UserControl page)
     {
-        panel.Controls.Clear();
+        if (panel is null)
+        {
+            throw new ArgumentNullException(nameof(panel));
+        }
 
-        panel.Controls.Add(page);
+        if (page is null)
+        {
+            throw new ArgumentNullException(nameof(page));
+        }
+
+        if (page.Parent is Panel currentParent && currentParent != panel)
+        {
+            currentParent.Controls.Remove(page);
+        }
+
+        for (int i = panel.Controls.Count - 1; i >= 0; i--)
+        {
+            var control = panel.Controls[i];
+            if (!ReferenceEquals(control, page))
+            {
+                panel.Controls.RemoveAt(i);
+            }
+        }
+
+        if (!panel.Controls.Contains(page))
+        {
+            panel.Controls.Add(page);
+        }
+
         page.Show();
+        page.BringToFront();
     }
 }


### PR DESCRIPTION
## Summary
- update PageManager to avoid disposing controls when switching between pages
- ensure existing pages are re-used without double clearing and bring the active page to front

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cac667acd483249a4d522a8a70b889