### PR TITLE
Improve splash screen status messages

### DIFF
--- a/WinUI/Forms/SplashScreenForm.cs
+++ b/WinUI/Forms/SplashScreenForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace WinUI.Forms;
@@ -8,6 +9,7 @@ public partial class SplashScreenForm : Form
 {
     private int _currentDotCount = 1;
     private const int MaxDots = 5;
+    private string _currentMessage = "Uygulama başlatılıyor";
 
     public SplashScreenForm()
     {
@@ -17,21 +19,48 @@ public partial class SplashScreenForm : Form
 
         LabelVersion.Text = $"v{versionInfo.FileVersion}";
 
+        UpdateLabelText();
+
         timer1.Interval = 300; // hızını ayarlarsın
         timer1.Start();
     }
 
     private void timer1_Tick(object sender, EventArgs e)
     {
-        label3.Text = GenerateDots(_currentDotCount);
+        UpdateDots();
+        UpdateLabelText();
+    }
+
+    private string GenerateDots(int count)
+    {
+        return string.Join(" ", Enumerable.Repeat(".", count));
+    }
+
+    private void UpdateDots()
+    {
         _currentDotCount++;
 
         if (_currentDotCount > MaxDots)
             _currentDotCount = 1;
     }
 
-    private string GenerateDots(int count)
+    private void UpdateLabelText()
     {
-        return string.Join(" ", Enumerable.Repeat(".", count));
+        label3.Text = string.IsNullOrWhiteSpace(_currentMessage)
+            ? GenerateDots(_currentDotCount)
+            : $"{_currentMessage} {GenerateDots(_currentDotCount)}";
+    }
+
+    public void UpdateStatus(string message)
+    {
+        if (InvokeRequired)
+        {
+            Invoke(() => UpdateStatus(message));
+            return;
+        }
+
+        _currentMessage = message;
+        _currentDotCount = 1;
+        UpdateLabelText();
     }
 }

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -20,6 +20,7 @@ namespace WinUI
             ApplicationConfiguration.Initialize();
 
             SplashScreenForm splash = new SplashScreenForm();
+            splash.UpdateStatus("Uygulama başlatılıyor...");
             var splashThread = new Thread(() =>
             {
                 Application.Run(splash);
@@ -27,21 +28,26 @@ namespace WinUI
             splashThread.SetApartmentState(ApartmentState.STA);
             splashThread.Start();
 
+            splash.UpdateStatus("Hizmet yapılandırması hazırlanıyor...");
             using var host = CreateHostBuilder(args).Build();
             var hostStarted = false;
 
             try
             {
+                splash.UpdateStatus("Arka plan servisleri başlatılıyor...");
                 host.StartAsync().GetAwaiter().GetResult();
                 hostStarted = true;
 
                 Log.Information(LogMessages.Program.ApplicationStarted);
                 Services = host.Services;
+                splash.UpdateStatus("Bağımlılıklar yükleniyor...");
                 using var scope = Services.CreateScope();
                 var services = scope.ServiceProvider;
 
+                splash.UpdateStatus("Ana ekran hazırlanıyor...");
                 var mainForm = services.GetRequiredService<MainForm>();
 
+                splash.UpdateStatus("Ana ekran açılıyor...");
                 splash.Invoke(() => splash.Close());
                 splashThread.Join();
 


### PR DESCRIPTION
## Summary
- show localized status text on the splash screen while the application loads
- expose a thread-safe `UpdateStatus` helper to update the message with animated dots
- update program startup to report each initialization step to the splash screen

## Testing
- `dotnet build WinUI/WinUI.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6c0cca08324a3fa512d3accf53c