### PR TITLE
Ensure SAIS API requests require a valid ticket

### DIFF
--- a/WinUI/Constants/LogMessages.cs
+++ b/WinUI/Constants/LogMessages.cs
@@ -12,6 +12,7 @@ public static class LogMessages
     public static class SaisApiService
     {
         public const string SessionNotFoundOrExpired = "SAIS oturumu bulunamadı veya süresi doldu. Bilet yenileniyor ve yeniden deneniyor.";
+        public const string TicketMissingOrExpired = "SAIS bileti eksik veya süresi dolmuş. İstek gönderilemedi.";
     }
 
     public static class DatabaseSelectionService

--- a/WinUI/Services/SaisApiService.cs
+++ b/WinUI/Services/SaisApiService.cs
@@ -61,6 +61,11 @@ public class SaisApiService : ISaisApiService
     private async Task<string?> PrepareAsync()
     {
         await _ticketService.EnsureTicketAsync();
+        if (!_ticketService.HasValidTicket())
+        {
+            _logger.LogWarning(LogMessages.SaisApiService.TicketMissingOrExpired);
+            return null;
+        }
         var endpoint = await _apiEndpointService.GetFirstAsync();
         if (endpoint == null)
         {


### PR DESCRIPTION
## Summary
- stop SAIS API calls when the ticket is missing or expired by checking validity after refresh
- add a dedicated log message for aborted SAIS API requests due to missing ticket

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaee9f39c832481ca94171a3462a4