### PR TITLE
Add hourly averages for analog sensors

### DIFF
--- a/Api/Controllers/PlcDataController.cs
+++ b/Api/Controllers/PlcDataController.cs
@@ -3,16 +3,21 @@ using Infrastructure.Services.PLC;
 using Application.Features.PlcData.Dtos;
 using Api.Constants;
 using AutoMapper;
+using Application.Services.PlcData;
 using Microsoft.Extensions.Logging;
 
 namespace Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class PlcDataController(IPlcDataCache dataCache, IMapper mapper, ILogger<PlcDataController> logger) : ControllerBase
+public class PlcDataController(
+    IPlcDataCache dataCache,
+    IMapper mapper,
+    ILogger<PlcDataController> logger,
+    IAnalogSensorStatisticsService statisticsService) : ControllerBase
 {
     [HttpGet]
-    public IActionResult GetLatest()
+    public async Task<IActionResult> GetLatest(CancellationToken cancellationToken)
     {
         var data = dataCache.GetLatest();
         if (data == null)
@@ -22,6 +27,7 @@ public class PlcDataController(IPlcDataCache dataCache, IMapper mapper, ILogger<
         }
 
         var dto = mapper.Map<PlcDataDto>(data);
+        dto.AnalogHourlyAverage = await statisticsService.GetHourlyAverageAsync(DateTime.Now, cancellationToken);
         return Ok(dto);
     }
 }

--- a/Application/ApplicationServiceRegistration.cs
+++ b/Application/ApplicationServiceRegistration.cs
@@ -16,6 +16,7 @@ public static class ApplicationServiceRegistration
         services.AddValidatorsFromAssembly(typeof(ApplicationServiceRegistration).Assembly);
         services.AddSingleton<IPlcDataParser, PlcDataParser>();
         services.AddTransient<IPlcDataReader, PlcDataReader>();
+        services.AddTransient<IAnalogSensorStatisticsService, AnalogSensorStatisticsService>();
         return services;
     }
 }

--- a/Application/Features/PlcData/Dtos/AnalogSensorAverageDto.cs
+++ b/Application/Features/PlcData/Dtos/AnalogSensorAverageDto.cs
@@ -1,0 +1,16 @@
+namespace Application.Features.PlcData.Dtos;
+
+/// <summary>
+/// Represents averaged analog sensor readings for a specific time window.
+/// </summary>
+public class AnalogSensorAverageDto
+{
+    public double? AkisHizi { get; set; }
+    public double? Akm { get; set; }
+    public double? CozunmusOksijen { get; set; }
+    public double? Debi { get; set; }
+    public double? Koi { get; set; }
+    public double? Ph { get; set; }
+    public double? Sicaklik { get; set; }
+    public double? Iletkenlik { get; set; }
+}

--- a/Application/Features/PlcData/Dtos/PlcDataDto.cs
+++ b/Application/Features/PlcData/Dtos/PlcDataDto.cs
@@ -10,4 +10,5 @@ public class PlcDataDto
     public required AnalogSensorDataDto Analog { get; set; }
     public required DigitalSensorDataDto Digital { get; set; }
     public required PlcTimeParametersDto TimeParameter { get; set; }
+    public AnalogSensorAverageDto AnalogHourlyAverage { get; set; } = new();
 }

--- a/Application/Features/PlcData/Profiles/PlcDataProfile.cs
+++ b/Application/Features/PlcData/Profiles/PlcDataProfile.cs
@@ -7,7 +7,8 @@ public class PlcDataProfile : Profile
 {
     public PlcDataProfile()
     {
-        CreateMap<Domain.Entities.PlcData, PlcDataDto>();
+        CreateMap<Domain.Entities.PlcData, PlcDataDto>()
+            .ForMember(dest => dest.AnalogHourlyAverage,
+                opt => opt.MapFrom(_ => new AnalogSensorAverageDto()));
     }
 }
-

--- a/Application/Services/PlcData/AnalogSensorStatisticsService.cs
+++ b/Application/Services/PlcData/AnalogSensorStatisticsService.cs
@@ -1,0 +1,41 @@
+using Application.Features.PlcData.Dtos;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Services.PlcData;
+
+public class AnalogSensorStatisticsService(IBKSContext context) : IAnalogSensorStatisticsService
+{
+    private readonly IBKSContext _context = context;
+
+    public async Task<AnalogSensorAverageDto> GetHourlyAverageAsync(DateTime referenceTime, CancellationToken cancellationToken = default)
+    {
+        DateTime endTime = referenceTime;
+        DateTime startTime = endTime.AddHours(-1);
+
+        var query = _context.AnalogSensorData
+            .Where(x => x.Readtime >= startTime && x.Readtime <= endTime);
+
+        if (!await query.AnyAsync(cancellationToken))
+        {
+            return new AnalogSensorAverageDto();
+        }
+
+        var averages = await query
+            .GroupBy(_ => 1)
+            .Select(g => new AnalogSensorAverageDto
+            {
+                AkisHizi = Math.Round(g.Average(x => x.AkisHizi), 2),
+                Akm = Math.Round(g.Average(x => x.Akm), 2),
+                CozunmusOksijen = Math.Round(g.Average(x => x.CozunmusOksijen), 2),
+                Debi = Math.Round(g.Average(x => x.Debi), 2),
+                Koi = Math.Round(g.Average(x => x.Koi), 2),
+                Ph = Math.Round(g.Average(x => x.Ph), 2),
+                Sicaklik = Math.Round(g.Average(x => x.Sicaklik), 2),
+                Iletkenlik = Math.Round(g.Average(x => x.Iletkenlik), 2)
+            })
+            .FirstAsync(cancellationToken);
+
+        return averages;
+    }
+}

--- a/Application/Services/PlcData/IAnalogSensorStatisticsService.cs
+++ b/Application/Services/PlcData/IAnalogSensorStatisticsService.cs
@@ -1,0 +1,8 @@
+using Application.Features.PlcData.Dtos;
+
+namespace Application.Services.PlcData;
+
+public interface IAnalogSensorStatisticsService
+{
+    Task<AnalogSensorAverageDto> GetHourlyAverageAsync(DateTime referenceTime, CancellationToken cancellationToken = default);
+}

--- a/WinUI/Models/AnalogSensorAverageDto.cs
+++ b/WinUI/Models/AnalogSensorAverageDto.cs
@@ -1,0 +1,13 @@
+namespace WinUI.Models;
+
+public class AnalogSensorAverageDto
+{
+    public double? AkisHizi { get; set; }
+    public double? Akm { get; set; }
+    public double? CozunmusOksijen { get; set; }
+    public double? Debi { get; set; }
+    public double? Koi { get; set; }
+    public double? Ph { get; set; }
+    public double? Sicaklik { get; set; }
+    public double? Iletkenlik { get; set; }
+}

--- a/WinUI/Models/PlcDataDto.cs
+++ b/WinUI/Models/PlcDataDto.cs
@@ -5,4 +5,5 @@ public class PlcDataDto
     public required AnalogSensorDataDto Analog { get; set; }
     public required DigitalSensorDataDto Digital { get; set; }
     public required PlcTimeParametersDto TimeParameter { get; set; }
+    public AnalogSensorAverageDto AnalogHourlyAverage { get; set; } = new();
 }

--- a/WinUI/Pages/HomePage.cs
+++ b/WinUI/Pages/HomePage.cs
@@ -72,6 +72,11 @@ namespace WinUI.Pages
             return _plcService.GetLatestAsync();
         }
 
+        private static string FormatAverage(double? value, string unit)
+        {
+            return value.HasValue ? $"{value.Value:0.##}{unit}" : "-";
+        }
+
         private async Task<ApiConnectionStatus> UpdateSaisConnectionStatusAsync()
         {
             try
@@ -251,14 +256,31 @@ namespace WinUI.Pages
                 if (value == null)
                     return;
 
+                var averages = value.AnalogHourlyAverage ?? new AnalogSensorAverageDto();
+
                 ChannelAkm.InstantData = $"{value.Analog.Akm} mg/l";
+                ChannelAkm.AvgDataOf60Min = FormatAverage(averages.Akm, " mg/l");
+
                 ChannelCozunmusOksijen.InstantData = $"{value.Analog.CozunmusOksijen} mg/l";
+                ChannelCozunmusOksijen.AvgDataOf60Min = FormatAverage(averages.CozunmusOksijen, " mg/l");
+
                 ChannelSicaklik.InstantData = $"{value.Analog.Sicaklik} mg/l";
+                ChannelSicaklik.AvgDataOf60Min = FormatAverage(averages.Sicaklik, " mg/l");
+
                 ChannelPh.InstantData = $"{value.Analog.Ph} mg/l";
+                ChannelPh.AvgDataOf60Min = FormatAverage(averages.Ph, " mg/l");
+
                 ChannelIletkenlik.InstantData = $"{value.Analog.Iletkenlik} mg/l";
+                ChannelIletkenlik.AvgDataOf60Min = FormatAverage(averages.Iletkenlik, " mg/l");
+
                 ChannelKoi.InstantData = $"{value.Analog.Koi} mg/l";
+                ChannelKoi.AvgDataOf60Min = FormatAverage(averages.Koi, " mg/l");
+
                 ChannelAkisHizi.InstantData = $"{value.Analog.AkisHizi} mg/l";
+                ChannelAkisHizi.AvgDataOf60Min = FormatAverage(averages.AkisHizi, " mg/l");
+
                 ChannelDebi.InstantData = $"{value.Analog.Debi} mg/l";
+                ChannelDebi.AvgDataOf60Min = FormatAverage(averages.Debi, " mg/l");
 
                 DigitalSensorKapi.SensorState = value.Digital.KabinKapiAcildi ? StateColors.Error : StateColors.Ok;
                 DigitalSensorDuman.SensorState = value.Digital.KabinDuman ? StateColors.Error : StateColors.Ok;


### PR DESCRIPTION
## Summary
- add an application service that calculates hourly averages for analog sensor readings
- expose the hourly averages through the PLC data API endpoint
- display the calculated averages in the WinUI home page instead of the placeholder text

## Testing
- `dotnet build ISKI.SAIS.MarbinYS.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f6e137cc8324ab636a8b3dfa0d6f