### PR TITLE
Improve home page connectivity status handling

### DIFF
--- a/WinUI/Models/ConnectionStatus.cs
+++ b/WinUI/Models/ConnectionStatus.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace WinUI.Models;
+
+/// <summary>
+/// Identifies the connection source whose health is being tracked.
+/// </summary>
+public enum ConnectionComponent
+{
+    Plc,
+    SaisApi
+}
+
+/// <summary>
+/// Represents the health of a remote dependency.
+/// </summary>
+public enum ConnectionState
+{
+    Unknown,
+    Connected,
+    NotConfigured,
+    NoAccess,
+    Unreachable
+}
+
+/// <summary>
+/// Event payload published when the connection status of a component changes.
+/// </summary>
+public sealed class ConnectionStatusChangedEventArgs : EventArgs
+{
+    public ConnectionStatusChangedEventArgs(ConnectionComponent component, ConnectionState state, string? message)
+    {
+        Component = component;
+        State = state;
+        Message = message;
+    }
+
+    public ConnectionComponent Component { get; }
+
+    public ConnectionState State { get; }
+
+    public string? Message { get; }
+}

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -86,6 +86,7 @@ namespace WinUI
                     services.AddSingleton<ReportingPage>();
                     services.AddSingleton<MailPage>();
                     services.AddSingleton<SettingsPage>();
+                    services.AddSingleton<IConnectionStatusService, ConnectionStatusService>();
 
                     services.AddHttpClient<IPlcDataService, PlcDataService>(client =>
                     {

--- a/WinUI/Services/ConnectionStatusService.cs
+++ b/WinUI/Services/ConnectionStatusService.cs
@@ -1,0 +1,53 @@
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IConnectionStatusService
+{
+    event EventHandler<ConnectionStatusChangedEventArgs>? StatusChanged;
+
+    ConnectionState GetStatus(ConnectionComponent component);
+
+    void ReportStatus(ConnectionComponent component, ConnectionState state, string? message = null);
+}
+
+/// <summary>
+/// Thread-safe component that keeps track of the connection state of the PLC and SAIS API.
+/// </summary>
+public sealed class ConnectionStatusService : IConnectionStatusService
+{
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<ConnectionComponent, (ConnectionState State, string? Message)> _states = new();
+
+    public event EventHandler<ConnectionStatusChangedEventArgs>? StatusChanged;
+
+    public ConnectionState GetStatus(ConnectionComponent component)
+    {
+        lock (_syncRoot)
+        {
+            return _states.TryGetValue(component, out var entry) ? entry.State : ConnectionState.Unknown;
+        }
+    }
+
+    public void ReportStatus(ConnectionComponent component, ConnectionState state, string? message = null)
+    {
+        bool hasChanged = false;
+        lock (_syncRoot)
+        {
+            if (_states.TryGetValue(component, out var existing) &&
+                existing.State == state &&
+                string.Equals(existing.Message, message, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _states[component] = (state, message);
+            hasChanged = true;
+        }
+
+        if (hasChanged)
+        {
+            StatusChanged?.Invoke(this, new ConnectionStatusChangedEventArgs(component, state, message));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add connection status model and service so PLC and SAIS API health changes can be broadcast across the UI
- update the home page to subscribe to connection status updates, adjust visuals for PLC/API outages, and centralize PLC failure handling
- extend SaisApiService and the DI setup to report API connectivity issues via the shared status service

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d508443f1c8324931ce28ed0d8ea26