### PR TITLE
Add SAIS API data retrieval to API settings page

### DIFF
--- a/Api/Controllers/SendDataController.cs
+++ b/Api/Controllers/SendDataController.cs
@@ -1,5 +1,6 @@
 using Application.Features.SendDatas.Queries.GetList;
 using Application.Features.SendDatas.Queries.GetById;
+using Application.Features.SendDatas.Queries.GetLatestReadTime;
 using MediatR;                     
 using Microsoft.AspNetCore.Mvc;
 using Application.Features.SendDatas.Commands;
@@ -15,6 +16,16 @@ public class SendDataController(IMediator mediator) : ControllerBase
     public async Task<IActionResult> GetList()
     {
         var result = await mediator.Send(new GetSendDataQuery());
+        return Ok(result);
+    }
+
+    [HttpGet("latest-readtime")]
+    public async Task<IActionResult> GetLatestReadTime()
+    {
+        var result = await mediator.Send(new GetLatestReadTimeQuery());
+        if (result is null)
+            return NotFound();
+
         return Ok(result);
     }
 

--- a/Application/Features/SendDatas/Queries/GetLatestReadTime/GetLatestReadTimeQuery.cs
+++ b/Application/Features/SendDatas/Queries/GetLatestReadTime/GetLatestReadTimeQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using System;
+
+namespace Application.Features.SendDatas.Queries.GetLatestReadTime;
+
+public record GetLatestReadTimeQuery() : IRequest<DateTime?>;

--- a/Application/Features/SendDatas/Queries/GetLatestReadTime/GetLatestReadTimeQueryHandler.cs
+++ b/Application/Features/SendDatas/Queries/GetLatestReadTime/GetLatestReadTimeQueryHandler.cs
@@ -1,0 +1,19 @@
+using Domain.Repositories;
+using MediatR;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Application.Features.SendDatas.Queries.GetLatestReadTime;
+
+public class GetLatestReadTimeQueryHandler(ISendDataRepository repository)
+    : IRequestHandler<GetLatestReadTimeQuery, DateTime?>
+{
+    public async Task<DateTime?> Handle(GetLatestReadTimeQuery request, CancellationToken cancellationToken)
+    {
+        var items = await repository.GetAllAsync(_ => true, query =>
+            query.OrderByDescending(x => x.Readtime).Take(1));
+
+        return items.FirstOrDefault()?.Readtime;
+    }
+}

--- a/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
@@ -52,7 +52,10 @@
             ResponseTextBox = new TextBox();
             RequestSampleButton = new Button();
             SendDiagnosticButton = new Button();
-            button1 = new Button();
+            PeriodLabel = new Label();
+            PeriodComboBox = new ComboBox();
+            GetLastDataButton = new Button();
+            GetHistoricalDataButton = new Button();
             StationInfoContentTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)DataSendPeriodNumericUpDown).BeginInit();
             StationInfoBgTableLayoutPanel.SuspendLayout();
@@ -319,7 +322,10 @@
             ApiTestContentTableLayoutPanel.Controls.Add(ResponseGroupBox, 1, 0);
             ApiTestContentTableLayoutPanel.Controls.Add(RequestSampleButton, 0, 1);
             ApiTestContentTableLayoutPanel.Controls.Add(SendDiagnosticButton, 0, 2);
-            ApiTestContentTableLayoutPanel.Controls.Add(button1, 0, 3);
+            ApiTestContentTableLayoutPanel.Controls.Add(PeriodLabel, 0, 3);
+            ApiTestContentTableLayoutPanel.Controls.Add(PeriodComboBox, 0, 4);
+            ApiTestContentTableLayoutPanel.Controls.Add(GetLastDataButton, 0, 5);
+            ApiTestContentTableLayoutPanel.Controls.Add(GetHistoricalDataButton, 0, 6);
             ApiTestContentTableLayoutPanel.Dock = DockStyle.Fill;
             ApiTestContentTableLayoutPanel.Location = new Point(1, 1);
             ApiTestContentTableLayoutPanel.Margin = new Padding(1);
@@ -406,17 +412,51 @@
             SendDiagnosticButton.Text = "Deneme Diagnostik Gönder";
             SendDiagnosticButton.UseVisualStyleBackColor = true;
             // 
-            // button1
-            // 
-            button1.Anchor = AnchorStyles.Left;
-            button1.AutoSize = true;
-            button1.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            button1.Location = new Point(18, 111);
-            button1.Name = "button1";
-            button1.Size = new Size(176, 25);
-            button1.TabIndex = 2;
-            button1.Text = "Son Veriyi Getir";
-            button1.UseVisualStyleBackColor = true;
+            // PeriodLabel
+            //
+            PeriodLabel.Anchor = AnchorStyles.Left;
+            PeriodLabel.AutoSize = true;
+            PeriodLabel.Font = new Font("Arial", 9.75F, FontStyle.Bold, GraphicsUnit.Point, 162);
+            PeriodLabel.ForeColor = Color.FromArgb(64, 64, 64);
+            PeriodLabel.Location = new Point(18, 111);
+            PeriodLabel.Name = "PeriodLabel";
+            PeriodLabel.Size = new Size(55, 16);
+            PeriodLabel.TabIndex = 4;
+            PeriodLabel.Text = "Periyot";
+            //
+            // PeriodComboBox
+            //
+            PeriodComboBox.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            PeriodComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            PeriodComboBox.FormattingEnabled = true;
+            PeriodComboBox.Location = new Point(18, 142);
+            PeriodComboBox.Name = "PeriodComboBox";
+            PeriodComboBox.Size = new Size(176, 23);
+            PeriodComboBox.TabIndex = 5;
+            //
+            // GetLastDataButton
+            //
+            GetLastDataButton.Anchor = AnchorStyles.Left;
+            GetLastDataButton.AutoSize = true;
+            GetLastDataButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            GetLastDataButton.Location = new Point(18, 173);
+            GetLastDataButton.Name = "GetLastDataButton";
+            GetLastDataButton.Size = new Size(176, 25);
+            GetLastDataButton.TabIndex = 6;
+            GetLastDataButton.Text = "Son Veriyi Getir";
+            GetLastDataButton.UseVisualStyleBackColor = true;
+            //
+            // GetHistoricalDataButton
+            //
+            GetHistoricalDataButton.Anchor = AnchorStyles.Left;
+            GetHistoricalDataButton.AutoSize = true;
+            GetHistoricalDataButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            GetHistoricalDataButton.Location = new Point(18, 204);
+            GetHistoricalDataButton.Name = "GetHistoricalDataButton";
+            GetHistoricalDataButton.Size = new Size(176, 25);
+            GetHistoricalDataButton.TabIndex = 7;
+            GetHistoricalDataButton.Text = "Geçmiş Tüm Veriyi Getir";
+            GetHistoricalDataButton.UseVisualStyleBackColor = true;
             // 
             // ApiSettingsPage
             // 
@@ -466,8 +506,11 @@
         private Button SendServerRequestButton;
         private Button RequestSampleButton;
         private Button SendDiagnosticButton;
+        private Label PeriodLabel;
+        private ComboBox PeriodComboBox;
+        private Button GetLastDataButton;
+        private Button GetHistoricalDataButton;
         private GroupBox ResponseGroupBox;
         private TextBox ResponseTextBox;
-        private Button button1;
     }
 }

--- a/WinUI/Pages/Settings/ApiSettingsPage.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.cs
@@ -1,10 +1,14 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading.Tasks;
 using System.Windows.Forms;
+using Domain.Entities;
 using WinUI.Constants;
 using WinUI.Models;
 using WinUI.Services;
@@ -19,8 +23,19 @@ public partial class ApiSettingsPage : UserControl
     private readonly HttpClient _localClient;
     private readonly ITicketService _ticketService;
     private readonly IStationService _stationService;
+    private readonly ISaisApiService _saisApiService;
+    private readonly ISendDataService _sendDataService;
     private int? _apiEndpointId;
     private readonly int[] _resendPeriodOptions = new[] { 24 * 60, 48 * 60, 7 * 24 * 60, 30 * 24 * 60, 90 * 24 * 60, 180 * 24 * 60, 365 * 24 * 60 };
+    private readonly PeriodOption[] _periodOptions =
+    {
+        new("1 Dakika", 1),
+        new("5 Dakika", 2),
+        new("30 Dakika", 4),
+        new("1 Saat", 8),
+        new("1 Gün", 16)
+    };
+    private static readonly JsonSerializerOptions JsonWriteOptions = new() { WriteIndented = true };
 
 
     public ApiSettingsPage()
@@ -31,6 +46,8 @@ public partial class ApiSettingsPage : UserControl
         _configuration = Program.Services.GetRequiredService<IConfiguration>();
         _ticketService = Program.Services.GetRequiredService<ITicketService>();
         _stationService = Program.Services.GetRequiredService<IStationService>();
+        _saisApiService = Program.Services.GetRequiredService<ISaisApiService>();
+        _sendDataService = Program.Services.GetRequiredService<ISendDataService>();
 
         var handler = new HttpClientHandler();
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
@@ -45,6 +62,8 @@ public partial class ApiSettingsPage : UserControl
         SendServerRequestButton.Click += SendServerRequestButton_Click;
         RequestSampleButton.Click += RequestSampleButton_Click;
         SendDiagnosticButton.Click += SendDiagnosticButton_Click;
+        GetLastDataButton.Click += GetLastDataButton_Click;
+        GetHistoricalDataButton.Click += GetHistoricalDataButton_Click;
 
         ResendPeriodComboBox.Items.AddRange(new object[]
         {
@@ -57,6 +76,12 @@ public partial class ApiSettingsPage : UserControl
             "Son 1 Yıl"
         });
         ResendPeriodComboBox.SelectedIndex = 0;
+
+        PeriodComboBox.Items.AddRange(_periodOptions);
+        if (PeriodComboBox.Items.Count > 0)
+        {
+            PeriodComboBox.SelectedIndex = 0;
+        }
     }
 
     private async void ApiSettingsPage_Load(object? sender, EventArgs e)
@@ -199,6 +224,80 @@ public partial class ApiSettingsPage : UserControl
         }
     }
 
+    private async void GetLastDataButton_Click(object? sender, EventArgs e)
+    {
+        await ExecuteSafeAsync(async () =>
+        {
+            var station = await _stationService.GetFirstAsync();
+            if (station == null)
+            {
+                ResponseTextBox.Text = FormatContent("İstasyon bilgisi bulunamadı.");
+                return;
+            }
+
+            int period = GetSelectedPeriodCode();
+            var result = await _saisApiService.GetLastDataAsync(station.StationId, period);
+            if (result == null)
+            {
+                ResponseTextBox.Text = FormatContent("Servisten yanıt alınamadı.");
+                return;
+            }
+
+            ResponseTextBox.Text = FormatContent(JsonSerializer.Serialize(result, JsonWriteOptions));
+        });
+    }
+
+    private async void GetHistoricalDataButton_Click(object? sender, EventArgs e)
+    {
+        await ExecuteSafeAsync(async () =>
+        {
+            var station = await _stationService.GetFirstAsync();
+            if (station == null)
+            {
+                ResponseTextBox.Text = FormatContent("İstasyon bilgisi bulunamadı.");
+                return;
+            }
+
+            int period = GetSelectedPeriodCode();
+            DateTime endDate = DateTime.Now;
+            DateTime? latestLocalReadTime = await _sendDataService.GetLatestReadTimeAsync();
+            DateTime startDate = ResolveStartDate(station, latestLocalReadTime, endDate);
+
+            var result = await _saisApiService.GetDataByBetweenTwoDateAsync(station.StationId, period, startDate, endDate);
+            if (result == null)
+            {
+                ResponseTextBox.Text = FormatContent("Servisten yanıt alınamadı.");
+                return;
+            }
+
+            if (result.objects is not { Count: > 0 })
+            {
+                ResponseTextBox.Text = FormatContent(JsonSerializer.Serialize(result, JsonWriteOptions));
+                return;
+            }
+
+            List<ApiDataResultDto> newItems = FilterMeasurements(result.objects, latestLocalReadTime);
+            foreach (var item in newItems)
+            {
+                var sendData = MapToSendData(item, station);
+                await _sendDataService.CreateAsync(sendData);
+            }
+
+            var summary = new
+            {
+                result.result,
+                result.message,
+                period,
+                startDate,
+                endDate,
+                fetchedCount = result.objects.Count,
+                savedCount = newItems.Count
+            };
+
+            ResponseTextBox.Text = FormatContent(JsonSerializer.Serialize(summary, JsonWriteOptions));
+        });
+    }
+
     private static string CombineUrl(string baseUrl, string relative)
     {
         return $"{baseUrl.TrimEnd('/')}/{relative}";
@@ -215,5 +314,109 @@ public partial class ApiSettingsPage : UserControl
         {
             return content;
         }
+    }
+
+    private int GetSelectedPeriodCode()
+    {
+        if (PeriodComboBox.SelectedItem is PeriodOption option)
+        {
+            return option.Code;
+        }
+
+        return _periodOptions[0].Code;
+    }
+
+    private static List<ApiDataResultDto> FilterMeasurements(IEnumerable<ApiDataResultDto> items, DateTime? latestLocalReadTime)
+    {
+        return items
+            .Where(item => latestLocalReadTime is null || item.ReadTime > latestLocalReadTime.Value)
+            .OrderBy(item => item.ReadTime)
+            .ToList();
+    }
+
+    private static SendData MapToSendData(ApiDataResultDto dto, StationDto station)
+    {
+        return new SendData
+        {
+            Stationid = station.StationId,
+            Readtime = dto.ReadTime,
+            SoftwareVersion = station.Software ?? string.Empty,
+            AkisHizi = dto.AkisHizi ?? 0,
+            AKM = dto.AKM ?? 0,
+            CozunmusOksijen = dto.CozunmusOksijen ?? 0,
+            Debi = dto.Debi ?? 0,
+            DesarjDebi = null,
+            HariciDebi = null,
+            HariciDebi2 = null,
+            KOi = dto.KOi ?? 0,
+            pH = dto.pH ?? 0,
+            Sicaklik = dto.Sicaklik ?? 0,
+            Iletkenlik = 0,
+            Period = dto.Period,
+            AkisHizi_Status = dto.AkisHizi_Status ?? 0,
+            AKM_Status = dto.AKM_Status ?? 0,
+            CozunmusOksijen_Status = dto.CozunmusOksijen_Status ?? 0,
+            Debi_Status = dto.Debi_Status ?? 0,
+            DesarjDebi_Status = null,
+            HariciDebi_Status = null,
+            HariciDebi2_Status = null,
+            KOi_Status = dto.KOi_Status ?? 0,
+            pH_Status = dto.pH_Status ?? 0,
+            Sicaklik_Status = dto.Sicaklik_Status ?? 0,
+            Iletkenlik_Status = string.Empty,
+            IsSent = true
+        };
+    }
+
+    private async Task ExecuteSafeAsync(Func<Task> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (Exception ex)
+        {
+            ResponseTextBox.Text = FormatContent(ex.Message);
+        }
+    }
+
+    private static DateTime ResolveStartDate(StationDto station, DateTime? latestLocalReadTime, DateTime endDate)
+    {
+        if (latestLocalReadTime.HasValue)
+        {
+            var candidate = latestLocalReadTime.Value.AddMinutes(1);
+            if (candidate < endDate)
+            {
+                return candidate;
+            }
+
+            return endDate.AddMinutes(-1);
+        }
+
+        if (station.SetupDate.HasValue)
+        {
+            return station.SetupDate.Value;
+        }
+
+        if (station.BirtDate.HasValue)
+        {
+            return station.BirtDate.Value;
+        }
+
+        return endDate.AddYears(-1);
+    }
+
+    private sealed class PeriodOption
+    {
+        public PeriodOption(string displayName, int code)
+        {
+            DisplayName = displayName;
+            Code = code;
+        }
+
+        public string DisplayName { get; }
+        public int Code { get; }
+
+        public override string ToString() => DisplayName;
     }
 }

--- a/WinUI/Services/SendDataService.cs
+++ b/WinUI/Services/SendDataService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net;
 using System.Net.Http.Json;
 using Domain.Entities;
 using WinUI.Constants;
@@ -7,6 +9,7 @@ namespace WinUI.Services;
 public interface ISendDataService
 {
     Task CreateAsync(SendData data);
+    Task<DateTime?> GetLatestReadTimeAsync();
 }
 
 public class SendDataService(HttpClient httpClient) : ISendDataService
@@ -15,5 +18,17 @@ public class SendDataService(HttpClient httpClient) : ISendDataService
     {
         using var response = await httpClient.PostAsJsonAsync(SendDataConstants.ApiUrl, data);
         response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<DateTime?> GetLatestReadTimeAsync()
+    {
+        using var response = await httpClient.GetAsync($"{SendDataConstants.ApiUrl}/latest-readtime");
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<DateTime?>();
     }
 }


### PR DESCRIPTION
## Summary
- add UI controls on the API settings page to choose SAIS data periods and trigger last-data and historical-data fetches
- call SAIS services to display the latest sample and persist fetched historical measurements into the local SendData store
- expose a backend query/controller endpoint so the UI can learn the latest stored read time and avoid duplicating records

## Testing
- dotnet build ISKI.SAIS.MarbinYS.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d509599c848324b772566cbaa139c0