### PR TITLE
Add scheduled resend of missing SAIS data

### DIFF
--- a/Api/Controllers/SendDataController.cs
+++ b/Api/Controllers/SendDataController.cs
@@ -1,9 +1,12 @@
+using System;
 using Application.Features.SendDatas.Queries.GetList;
 using Application.Features.SendDatas.Queries.GetById;
-using MediatR;                     
+using Application.Features.SendDatas.Queries.GetByStationAndReadTime;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Application.Features.SendDatas.Commands;
 using Application.Features.SendDatas.Commands.Create;
+using Application.Features.SendDatas.Commands.Update;
 
 namespace Api.Controllers;
 
@@ -26,10 +29,33 @@ public class SendDataController(IMediator mediator) : ControllerBase
             return NotFound();
         return Ok(result);
     }
+
+    [HttpGet("by-station-and-readtime")]
+    public async Task<IActionResult> GetByStationAndReadTime([FromQuery] Guid stationId, [FromQuery] DateTime readTime)
+    {
+        var result = await mediator.Send(new GetSendDataByStationAndReadTimeQuery(stationId, readTime));
+        if (result is null)
+            return NotFound();
+        return Ok(result);
+    }
+
     [HttpPost]
     public async Task<IActionResult> Create(CreateSendDataCommand command)
     {
         var result = await mediator.Send(command);
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/status")]
+    public async Task<IActionResult> UpdateStatus(int id, UpdateSendDataStatusCommand command)
+    {
+        if (id != command.Id)
+            return BadRequest();
+
+        var result = await mediator.Send(command);
+        if (result is null)
+            return NotFound();
+
         return Ok(result);
     }
 

--- a/Application/Features/SendDatas/Commands/Update/UpdateSendDataStatusCommand.cs
+++ b/Application/Features/SendDatas/Commands/Update/UpdateSendDataStatusCommand.cs
@@ -1,0 +1,17 @@
+using Application.Features.SendDatas.Dtos;
+using MediatR;
+
+namespace Application.Features.SendDatas.Commands.Update;
+
+public class UpdateSendDataStatusCommand : IRequest<SendDataDto?>
+{
+    public int Id { get; set; }
+    public bool? IsSent { get; set; }
+    public bool SaatlikYikamaGecersiz { get; set; }
+    public bool HaftalikYikamaGecersiz { get; set; }
+    public bool KalibrasyonGecersiz { get; set; }
+    public bool AkisHiziGecersiz { get; set; }
+    public bool GecersizDebi { get; set; }
+    public bool TekrarVeriGecersiz { get; set; }
+    public bool GecersizOlcumBirimi { get; set; }
+}

--- a/Application/Features/SendDatas/Commands/Update/UpdateSendDataStatusCommandHandler.cs
+++ b/Application/Features/SendDatas/Commands/Update/UpdateSendDataStatusCommandHandler.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Features.SendDatas.Dtos;
+using AutoMapper;
+using Domain.Repositories;
+using MediatR;
+
+namespace Application.Features.SendDatas.Commands.Update;
+
+public class UpdateSendDataStatusCommandHandler(
+    ISendDataRepository repository,
+    IMapper mapper) : IRequestHandler<UpdateSendDataStatusCommand, SendDataDto?>
+{
+    public async Task<SendDataDto?> Handle(UpdateSendDataStatusCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await repository.GetByIdAsync(request.Id);
+        if (entity is null)
+            return null;
+
+        entity.IsSent = request.IsSent;
+        entity.SaatlikYikamaGecersiz = request.SaatlikYikamaGecersiz;
+        entity.HaftalikYikamaGecersiz = request.HaftalikYikamaGecersiz;
+        entity.KalibrasyonGecersiz = request.KalibrasyonGecersiz;
+        entity.AkisHiziGecersiz = request.AkisHiziGecersiz;
+        entity.GecersizDebi = request.GecersizDebi;
+        entity.TekrarVeriGecersiz = request.TekrarVeriGecersiz;
+        entity.GecersizOlcumBirimi = request.GecersizOlcumBirimi;
+
+        var updated = await repository.UpdateAsync(entity);
+        return mapper.Map<SendDataDto>(updated);
+    }
+}

--- a/Application/Features/SendDatas/Queries/GetByStationAndReadTime/GetSendDataByStationAndReadTimeQuery.cs
+++ b/Application/Features/SendDatas/Queries/GetByStationAndReadTime/GetSendDataByStationAndReadTimeQuery.cs
@@ -1,0 +1,7 @@
+using Application.Features.SendDatas.Dtos;
+using MediatR;
+using System;
+
+namespace Application.Features.SendDatas.Queries.GetByStationAndReadTime;
+
+public sealed record GetSendDataByStationAndReadTimeQuery(Guid StationId, DateTime Readtime) : IRequest<SendDataDto?>;

--- a/Application/Features/SendDatas/Queries/GetByStationAndReadTime/GetSendDataByStationAndReadTimeQueryHandler.cs
+++ b/Application/Features/SendDatas/Queries/GetByStationAndReadTime/GetSendDataByStationAndReadTimeQueryHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Features.SendDatas.Dtos;
+using AutoMapper;
+using Domain.Repositories;
+using MediatR;
+
+namespace Application.Features.SendDatas.Queries.GetByStationAndReadTime;
+
+public sealed class GetSendDataByStationAndReadTimeQueryHandler(
+    ISendDataRepository repository,
+    IMapper mapper) : IRequestHandler<GetSendDataByStationAndReadTimeQuery, SendDataDto?>
+{
+    public async Task<SendDataDto?> Handle(GetSendDataByStationAndReadTimeQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await repository.GetAsync(x => x.Stationid == request.StationId && x.Readtime == request.Readtime);
+        if (entity is null)
+            return null;
+
+        return mapper.Map<SendDataDto>(entity);
+    }
+}

--- a/WinUI/Constants/LogMessages.cs
+++ b/WinUI/Constants/LogMessages.cs
@@ -38,6 +38,18 @@ public static class LogMessages
         public const string PlcApiError = "PLC API hatası {StatusCode}: {Error}";
     }
 
+    public static class MissingDataResendService
+    {
+        public const string UnexpectedError = "Eksik veriler yeniden gönderilirken beklenmeyen bir hata oluştu.";
+        public const string MissingDatesRequestFailed = "Eksik veri tarihleri isteği gönderilemedi.";
+        public const string MissingDatesResponseInvalid = "Eksik veri tarihleri alınamadı: {Message}";
+        public const string DataNotFound = "{MissingDate:o} zamanlı veri yerel veritabanında bulunamadı.";
+        public const string SendDataRequestFailed = "{MissingDate:o} zamanlı veri SAİS'e gönderilemedi.";
+        public const string SendDataFailed = "{MissingDate:o} zamanlı veri SAİS'e gönderilirken hata alındı: {Message}";
+        public const string InvalidStatusCodesReceived = "{MissingDate:o} zamanlı veri için geçersiz durum kodları alındı: {Codes}";
+        public const string UpdateStatusFailed = "{Id} kimlikli gönderi kaydı güncellenemedi.";
+    }
+
     public static class HomePage
     {
         public const string PlcConfigurationMissing = "PLC yapılandırması eksik: IP adresi tanımlı değil";

--- a/WinUI/Models/SendDataRecord.cs
+++ b/WinUI/Models/SendDataRecord.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace WinUI.Models;
+
+public class SendDataRecord
+{
+    public int Id { get; set; }
+    public Guid Stationid { get; set; }
+    public DateTime Readtime { get; set; }
+    public string SoftwareVersion { get; set; } = string.Empty;
+    public double AkisHizi { get; set; }
+    public double AKM { get; set; }
+    public double CozunmusOksijen { get; set; }
+    public double Debi { get; set; }
+    public double? DesarjDebi { get; set; }
+    public double? HariciDebi { get; set; }
+    public double? HariciDebi2 { get; set; }
+    public double KOi { get; set; }
+    public double pH { get; set; }
+    public double Sicaklik { get; set; }
+    public double Iletkenlik { get; set; }
+    public int Period { get; set; }
+    public int AkisHizi_Status { get; set; }
+    public int AKM_Status { get; set; }
+    public int CozunmusOksijen_Status { get; set; }
+    public int Debi_Status { get; set; }
+    public int? DesarjDebi_Status { get; set; }
+    public int? HariciDebi_Status { get; set; }
+    public int? HariciDebi2_Status { get; set; }
+    public int KOi_Status { get; set; }
+    public int pH_Status { get; set; }
+    public int Sicaklik_Status { get; set; }
+    public string Iletkenlik_Status { get; set; } = string.Empty;
+    public bool? IsSent { get; set; }
+    public bool SaatlikYikamaGecersiz { get; set; }
+    public bool HaftalikYikamaGecersiz { get; set; }
+    public bool KalibrasyonGecersiz { get; set; }
+    public bool AkisHiziGecersiz { get; set; }
+    public bool GecersizDebi { get; set; }
+    public bool TekrarVeriGecersiz { get; set; }
+    public bool GecersizOlcumBirimi { get; set; }
+}

--- a/WinUI/Models/SendDataStatusUpdateRequest.cs
+++ b/WinUI/Models/SendDataStatusUpdateRequest.cs
@@ -1,0 +1,14 @@
+namespace WinUI.Models;
+
+public class SendDataStatusUpdateRequest
+{
+    public int Id { get; set; }
+    public bool? IsSent { get; set; }
+    public bool SaatlikYikamaGecersiz { get; set; }
+    public bool HaftalikYikamaGecersiz { get; set; }
+    public bool KalibrasyonGecersiz { get; set; }
+    public bool AkisHiziGecersiz { get; set; }
+    public bool GecersizDebi { get; set; }
+    public bool TekrarVeriGecersiz { get; set; }
+    public bool GecersizOlcumBirimi { get; set; }
+}

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -299,6 +299,7 @@ namespace WinUI
                     services.AddSingleton<IDatabaseSelectionService, DatabaseSelectionService>();
                     services.AddHostedService<TicketRefreshService>();
                     services.AddHostedService<PlcDataSendService>();
+                    services.AddHostedService<MissingDataResendService>();
                 });
         }
     }

--- a/WinUI/Services/MissingDataResendService.cs
+++ b/WinUI/Services/MissingDataResendService.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public class MissingDataResendService : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
+    private readonly ISaisApiService _saisApiService;
+    private readonly IStationService _stationService;
+    private readonly ISendDataService _sendDataService;
+    private readonly ILogger<MissingDataResendService> _logger;
+
+    public MissingDataResendService(
+        ISaisApiService saisApiService,
+        IStationService stationService,
+        ISendDataService sendDataService,
+        ILogger<MissingDataResendService> logger)
+    {
+        _saisApiService = saisApiService;
+        _stationService = stationService;
+        _sendDataService = sendDataService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessMissingDatesAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, LogMessages.MissingDataResendService.UnexpectedError);
+            }
+
+            try
+            {
+                await Task.Delay(Interval, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // cancellation requested, exit loop on next iteration
+            }
+        }
+    }
+
+    private async Task ProcessMissingDatesAsync(CancellationToken cancellationToken)
+    {
+        var station = await _stationService.GetFirstAsync();
+        if (station is null)
+        {
+            _logger.LogWarning(LogMessages.PlcDataSendService.StationInfoNotFound);
+            return;
+        }
+
+        ResultStatus<MissingDatesDto>? response;
+        try
+        {
+            response = await _saisApiService.GetMissingDatesAsync(station.StationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, LogMessages.MissingDataResendService.MissingDatesRequestFailed);
+            return;
+        }
+
+        if (response?.result != true)
+        {
+            var message = response?.message ?? LogMessages.PlcDataSendService.UnknownError;
+            _logger.LogWarning(LogMessages.MissingDataResendService.MissingDatesResponseInvalid, message);
+            return;
+        }
+
+        var missingDates = response.objects?.MissingDates ?? new List<DateTime>();
+        if (missingDates.Count == 0)
+            return;
+
+        foreach (var missingDate in missingDates.OrderBy(date => date))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            var record = await _sendDataService.GetByReadTimeAsync(station.StationId, missingDate);
+            if (record is null)
+            {
+                _logger.LogInformation(LogMessages.MissingDataResendService.DataNotFound, missingDate);
+                continue;
+            }
+
+            await ResendAsync(record);
+        }
+    }
+
+    private async Task ResendAsync(SendDataRecord record)
+    {
+        ApiSendDataDto payload = CreatePayload(record);
+        ResultStatus<SendDataResult>? sendResponse;
+        try
+        {
+            sendResponse = await _saisApiService.SendDataAsync(payload);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, LogMessages.MissingDataResendService.SendDataRequestFailed, record.Readtime);
+            return;
+        }
+
+        var invalidCodes = SendDataResultEvaluator.ExtractInvalidStatusCodes(sendResponse?.objects);
+        if (invalidCodes.Count > 0)
+        {
+            var codes = string.Join(", ", invalidCodes.Select(code => ((int)code).ToString()));
+            _logger.LogWarning(LogMessages.MissingDataResendService.InvalidStatusCodesReceived, record.Readtime, codes);
+        }
+
+        var success = sendResponse?.result == true;
+        if (!success)
+        {
+            var message = sendResponse?.message ?? LogMessages.PlcDataSendService.UnknownError;
+            _logger.LogWarning(LogMessages.MissingDataResendService.SendDataFailed, record.Readtime, message);
+        }
+
+        var flags = SendDataResultEvaluator.MapInvalidStatusFlags(invalidCodes);
+        var updateRequest = new SendDataStatusUpdateRequest
+        {
+            Id = record.Id,
+            IsSent = success,
+            SaatlikYikamaGecersiz = flags.SaatlikYikamaGecersiz,
+            HaftalikYikamaGecersiz = flags.HaftalikYikamaGecersiz,
+            KalibrasyonGecersiz = flags.KalibrasyonGecersiz,
+            AkisHiziGecersiz = flags.AkisHiziGecersiz,
+            GecersizDebi = flags.GecersizDebi,
+            TekrarVeriGecersiz = flags.TekrarVeriGecersiz,
+            GecersizOlcumBirimi = flags.GecersizOlcumBirimi
+        };
+
+        var updated = await _sendDataService.UpdateStatusAsync(updateRequest);
+        if (!updated)
+        {
+            _logger.LogWarning(LogMessages.MissingDataResendService.UpdateStatusFailed, record.Id);
+        }
+    }
+
+    private static ApiSendDataDto CreatePayload(SendDataRecord record)
+    {
+        return new ApiSendDataDto
+        {
+            Id = record.Id,
+            Stationid = record.Stationid,
+            Readtime = record.Readtime,
+            SoftwareVersion = record.SoftwareVersion,
+            AkisHizi = record.AkisHizi,
+            AKM = record.AKM,
+            CozunmusOksijen = record.CozunmusOksijen,
+            Debi = record.Debi,
+            DesarjDebi = record.DesarjDebi,
+            HariciDebi = record.HariciDebi,
+            HariciDebi2 = record.HariciDebi2,
+            KOi = record.KOi,
+            pH = record.pH,
+            Sicaklik = record.Sicaklik,
+            Iletkenlik = record.Iletkenlik,
+            Period = record.Period,
+            AkisHizi_Status = record.AkisHizi_Status,
+            AKM_Status = record.AKM_Status,
+            CozunmusOksijen_Status = record.CozunmusOksijen_Status,
+            Debi_Status = record.Debi_Status,
+            DesarjDebi_Status = record.DesarjDebi_Status,
+            HariciDebi_Status = record.HariciDebi_Status,
+            HariciDebi2_Status = record.HariciDebi2_Status,
+            KOi_Status = record.KOi_Status,
+            pH_Status = record.pH_Status,
+            Sicaklik_Status = record.Sicaklik_Status,
+            Iletkenlik_Status = record.Iletkenlik_Status
+        };
+    }
+}

--- a/WinUI/Services/SendDataResultEvaluator.cs
+++ b/WinUI/Services/SendDataResultEvaluator.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Domain.Enums;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public static class SendDataResultEvaluator
+{
+    public static HashSet<InvalidSensorStatusCode> ExtractInvalidStatusCodes(SendDataResult? result)
+    {
+        var codes = new HashSet<InvalidSensorStatusCode>();
+        if (result is null)
+            return codes;
+
+        foreach (var property in typeof(SendDataResult).GetProperties())
+        {
+            if (!property.Name.EndsWith("_N", StringComparison.Ordinal))
+                continue;
+
+            var value = property.GetValue(result);
+            if (value is null)
+                continue;
+
+            if (!double.TryParse(value.ToString(), out var numericValue))
+                continue;
+
+            var intValue = (int)Math.Round(numericValue, MidpointRounding.AwayFromZero);
+            if (!Enum.IsDefined(typeof(InvalidSensorStatusCode), intValue))
+                continue;
+
+            codes.Add((InvalidSensorStatusCode)intValue);
+        }
+
+        return codes;
+    }
+
+    public static SendDataInvalidStatusFlags MapInvalidStatusFlags(IReadOnlyCollection<InvalidSensorStatusCode> invalidCodes)
+    {
+        bool Contains(InvalidSensorStatusCode code) => invalidCodes.Contains(code);
+
+        return new SendDataInvalidStatusFlags(
+            Contains(InvalidSensorStatusCode.GecersizYikama),
+            Contains(InvalidSensorStatusCode.GecersizHaftalikYikama),
+            Contains(InvalidSensorStatusCode.GecersizKalibrasyon),
+            Contains(InvalidSensorStatusCode.GecersizAkisHizi),
+            Contains(InvalidSensorStatusCode.GecersizDebi),
+            Contains(InvalidSensorStatusCode.TekrarVeri),
+            Contains(InvalidSensorStatusCode.GecersizOlcumBirimi));
+    }
+}
+
+public readonly record struct SendDataInvalidStatusFlags(
+    bool SaatlikYikamaGecersiz,
+    bool HaftalikYikamaGecersiz,
+    bool KalibrasyonGecersiz,
+    bool AkisHiziGecersiz,
+    bool GecersizDebi,
+    bool TekrarVeriGecersiz,
+    bool GecersizOlcumBirimi);

--- a/WinUI/Services/SendDataService.cs
+++ b/WinUI/Services/SendDataService.cs
@@ -1,19 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Domain.Entities;
+using Microsoft.AspNetCore.WebUtilities;
 using WinUI.Constants;
+using WinUI.Models;
 
 namespace WinUI.Services;
 
 public interface ISendDataService
 {
     Task CreateAsync(SendData data);
+    Task<SendDataRecord?> GetByReadTimeAsync(Guid stationId, DateTime readTime);
+    Task<bool> UpdateStatusAsync(SendDataStatusUpdateRequest request);
 }
 
 public class SendDataService(HttpClient httpClient) : ISendDataService
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNameCaseInsensitive = true };
+
     public async Task CreateAsync(SendData data)
     {
         using var response = await httpClient.PostAsJsonAsync(SendDataConstants.ApiUrl, data);
         response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<SendDataRecord?> GetByReadTimeAsync(Guid stationId, DateTime readTime)
+    {
+        var query = new Dictionary<string, string?>
+        {
+            ["stationId"] = stationId.ToString(),
+            ["readTime"] = readTime.ToString("O")
+        };
+
+        var url = QueryHelpers.AddQueryString($"{SendDataConstants.ApiUrl}/by-station-and-readtime", query);
+        using var response = await httpClient.GetAsync(url);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SendDataRecord>(SerializerOptions);
+    }
+
+    public async Task<bool> UpdateStatusAsync(SendDataStatusUpdateRequest request)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{SendDataConstants.ApiUrl}/{request.Id}/status", request);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return false;
+
+        response.EnsureSuccessStatusCode();
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add application support for retrieving send data by timestamp and updating its send status
- expose API endpoints for querying stored send data and persisting resend outcomes
- extend the WinUI client with a scheduled service, models, and helpers to resend missing SAIS measurements

## Testing
- dotnet build ISKI.SAIS.MarbinYS.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d509b3e30483248060dc228fea0f0d