### PR TITLE
Prevent duplicate SendData by readtime

### DIFF
--- a/Application/Features/SendDatas/Commands/Create/CreateSendDataCommandHandler.cs
+++ b/Application/Features/SendDatas/Commands/Create/CreateSendDataCommandHandler.cs
@@ -15,6 +15,14 @@ public class CreateSendDataCommandHandler(
 {
     public async Task<SendDataDto> Handle(CreateSendDataCommand request, CancellationToken cancellationToken)
     {
+        var existingEntity = await repository.GetAsync(
+            x => x.Stationid == request.Stationid &&
+                 x.Readtime == request.Readtime &&
+                 x.DeletedAt == null);
+
+        if (existingEntity is not null)
+            return mapper.Map<SendDataDto>(existingEntity);
+
         var entity = new SendData
         {
             Stationid = request.Stationid,


### PR DESCRIPTION
## Summary
- prevent duplicate SendData creation when a record already exists for the same station and readtime

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5307b94fc83249bacdbf9b3f590c6