### PR TITLE
Add SendData&Calibrations import workflow

### DIFF
--- a/WinUI/Constants/ExternalSaisApiConstants.cs
+++ b/WinUI/Constants/ExternalSaisApiConstants.cs
@@ -1,0 +1,8 @@
+namespace WinUI.Constants;
+
+public static class ExternalSaisApiConstants
+{
+    public const string SendDataEndpoint = "SendData";
+    public const string SendCalibrationEndpoint = "SendCalibration";
+    public const string DefaultInfoTitle = "SendData & Calibration";
+}

--- a/WinUI/Models/ExternalSaisModels.cs
+++ b/WinUI/Models/ExternalSaisModels.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace WinUI.Models;
+
+public class ExternalSendDataDto
+{
+    [JsonPropertyName("Stationid")]
+    public Guid StationId { get; set; }
+
+    [JsonPropertyName("Readtime")]
+    public DateTime ReadTime { get; set; }
+
+    [JsonPropertyName("SoftwareVersion")]
+    public string? SoftwareVersion { get; set; }
+
+    [JsonPropertyName("AkisHizi")]
+    public double? AkisHizi { get; set; }
+
+    [JsonPropertyName("AKM")]
+    public double? AKM { get; set; }
+
+    [JsonPropertyName("CozunmusOksijen")]
+    public double? CozunmusOksijen { get; set; }
+
+    [JsonPropertyName("Debi")]
+    public double? Debi { get; set; }
+
+    [JsonPropertyName("DesarjDebi")]
+    public double? DesarjDebi { get; set; }
+
+    [JsonPropertyName("HariciDebi")]
+    public double? HariciDebi { get; set; }
+
+    [JsonPropertyName("HariciDebi2")]
+    public double? HariciDebi2 { get; set; }
+
+    [JsonPropertyName("KOi")]
+    public double? KOi { get; set; }
+
+    [JsonPropertyName("pH")]
+    public double? pH { get; set; }
+
+    [JsonPropertyName("Sicaklik")]
+    public double? Sicaklik { get; set; }
+
+    [JsonPropertyName("Iletkenlik")]
+    public double? Iletkenlik { get; set; }
+
+    [JsonPropertyName("Period")]
+    public int? Period { get; set; }
+
+    [JsonPropertyName("AkisHizi_Status")]
+    public int? AkisHiziStatus { get; set; }
+
+    [JsonPropertyName("AKM_Status")]
+    public int? AKMStatus { get; set; }
+
+    [JsonPropertyName("CozunmusOksijen_Status")]
+    public int? CozunmusOksijenStatus { get; set; }
+
+    [JsonPropertyName("Debi_Status")]
+    public int? DebiStatus { get; set; }
+
+    [JsonPropertyName("DesarjDebi_Status")]
+    public int? DesarjDebiStatus { get; set; }
+
+    [JsonPropertyName("HariciDebi_Status")]
+    public int? HariciDebiStatus { get; set; }
+
+    [JsonPropertyName("HariciDebi2_Status")]
+    public int? HariciDebi2Status { get; set; }
+
+    [JsonPropertyName("KOi_Status")]
+    public int? KOiStatus { get; set; }
+
+    [JsonPropertyName("pH_Status")]
+    public int? pHStatus { get; set; }
+
+    [JsonPropertyName("Sicaklik_Status")]
+    public int? SicaklikStatus { get; set; }
+
+    [JsonPropertyName("Iletkenlik_Status")]
+    public string? IletkenlikStatus { get; set; }
+
+    [JsonPropertyName("IsSent")]
+    public bool? IsSent { get; set; }
+
+    [JsonPropertyName("SaatlikYikamaGecersiz")]
+    public bool? SaatlikYikamaGecersiz { get; set; }
+
+    [JsonPropertyName("HaftalikYikamaGecersiz")]
+    public bool? HaftalikYikamaGecersiz { get; set; }
+
+    [JsonPropertyName("KalibrasyonGecersiz")]
+    public bool? KalibrasyonGecersiz { get; set; }
+
+    [JsonPropertyName("AkisHiziGecersiz")]
+    public bool? AkisHiziGecersiz { get; set; }
+
+    [JsonPropertyName("GecersizDebi")]
+    public bool? GecersizDebi { get; set; }
+
+    [JsonPropertyName("TekrarVeriGecersiz")]
+    public bool? TekrarVeriGecersiz { get; set; }
+
+    [JsonPropertyName("GecersizOlcumBirimi")]
+    public bool? GecersizOlcumBirimi { get; set; }
+}
+
+public class ExternalCalibrationRecordDto
+{
+    [JsonPropertyName("CalibrationDate")]
+    public DateTime CalibrationDate { get; set; }
+
+    [JsonPropertyName("DBColumnName")]
+    public string? DBColumnName { get; set; }
+
+    [JsonPropertyName("ZeroRef")]
+    public double? ZeroRef { get; set; }
+
+    [JsonPropertyName("ZeroMeas")]
+    public double? ZeroMeas { get; set; }
+
+    [JsonPropertyName("ZeroDiff")]
+    public double? ZeroDiff { get; set; }
+
+    [JsonPropertyName("ZeroSTD")]
+    public double? ZeroStd { get; set; }
+
+    [JsonPropertyName("SpanRef")]
+    public double? SpanRef { get; set; }
+
+    [JsonPropertyName("SpanMeas")]
+    public double? SpanMeas { get; set; }
+
+    [JsonPropertyName("SpanDiff")]
+    public double? SpanDiff { get; set; }
+
+    [JsonPropertyName("SpanSTD")]
+    public double? SpanStd { get; set; }
+
+    [JsonPropertyName("ResultFactor")]
+    public double? ResultFactor { get; set; }
+
+    [JsonPropertyName("ResultZero")]
+    public bool? ResultZero { get; set; }
+
+    [JsonPropertyName("ResultSpan")]
+    public bool? ResultSpan { get; set; }
+
+    [JsonPropertyName("Result")]
+    public bool? Result { get; set; }
+}

--- a/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.Designer.cs
@@ -334,6 +334,7 @@ namespace WinUI.Pages.Settings
             ApiTestContentTableLayoutPanel.Controls.Add(EndDatePicker, 0, 8);
             ApiTestContentTableLayoutPanel.Controls.Add(GetLastDataButton, 0, 9);
             ApiTestContentTableLayoutPanel.Controls.Add(GetHistoricalDataButton, 0, 10);
+            ApiTestContentTableLayoutPanel.Controls.Add(SendDataAndCalibrationsButton, 0, 11);
             ApiTestContentTableLayoutPanel.Dock = DockStyle.Fill;
             ApiTestContentTableLayoutPanel.Location = new Point(1, 1);
             ApiTestContentTableLayoutPanel.Margin = new Padding(1);
@@ -510,6 +511,18 @@ namespace WinUI.Pages.Settings
             GetHistoricalDataButton.TabIndex = 13;
             GetHistoricalDataButton.Text = "Geçmiş Tüm Veriyi Getir";
             GetHistoricalDataButton.UseVisualStyleBackColor = true;
+            //
+            // SendDataAndCalibrationsButton
+            //
+            SendDataAndCalibrationsButton.Anchor = AnchorStyles.Left;
+            SendDataAndCalibrationsButton.AutoSize = true;
+            SendDataAndCalibrationsButton.Font = new Font("Arial", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            SendDataAndCalibrationsButton.Location = new Point(18, 359);
+            SendDataAndCalibrationsButton.Name = "SendDataAndCalibrationsButton";
+            SendDataAndCalibrationsButton.Size = new Size(176, 25);
+            SendDataAndCalibrationsButton.TabIndex = 14;
+            SendDataAndCalibrationsButton.Text = "SendData&Calibrations";
+            SendDataAndCalibrationsButton.UseVisualStyleBackColor = true;
             // 
             // ApiSettingsPage
             // 
@@ -569,5 +582,6 @@ namespace WinUI.Pages.Settings
         private Button GetHistoricalDataButton;
         private GroupBox ResponseGroupBox;
         private TextBox ResponseTextBox;
+        private Button SendDataAndCalibrationsButton;
     }
 }

--- a/WinUI/Pages/Settings/ApiSettingsPage.cs
+++ b/WinUI/Pages/Settings/ApiSettingsPage.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Windows.Forms;
 using Domain.Entities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System.Net.Http.Json;
-using System.Text.Json;
 using WinUI.Constants;
 using WinUI.Models;
 using WinUI.Services;
@@ -20,6 +24,7 @@ public partial class ApiSettingsPage : UserControl
     private readonly ISaisApiService _saisApiService;
     private readonly ISendDataService _sendDataService;
     private readonly IMeasurementReportService _measurementReportService;
+    private readonly IExternalDataImportService _externalDataImportService;
     private int? _apiEndpointId;
     private readonly int[] _resendPeriodOptions = new[] { 24 * 60, 48 * 60, 7 * 24 * 60, 30 * 24 * 60, 90 * 24 * 60, 180 * 24 * 60, 365 * 24 * 60 };
     private readonly PeriodOption[] _periodOptions =
@@ -44,6 +49,7 @@ public partial class ApiSettingsPage : UserControl
         _saisApiService = Program.Services.GetRequiredService<ISaisApiService>();
         _sendDataService = Program.Services.GetRequiredService<ISendDataService>();
         _measurementReportService = Program.Services.GetRequiredService<IMeasurementReportService>();
+        _externalDataImportService = Program.Services.GetRequiredService<IExternalDataImportService>();
 
         var handler = new HttpClientHandler();
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
@@ -60,6 +66,7 @@ public partial class ApiSettingsPage : UserControl
         SendDiagnosticButton.Click += SendDiagnosticButton_Click;
         GetLastDataButton.Click += GetLastDataButton_Click;
         GetHistoricalDataButton.Click += GetHistoricalDataButton_Click;
+        SendDataAndCalibrationsButton.Click += SendDataAndCalibrationsButton_Click;
 
         ResendPeriodComboBox.Items.AddRange(new object[]
         {
@@ -300,6 +307,49 @@ public partial class ApiSettingsPage : UserControl
                 await _sendDataService.CreateAsync(sendData);
             }
         });
+    }
+
+    private async void SendDataAndCalibrationsButton_Click(object? sender, EventArgs e)
+    {
+        try
+        {
+            ResponseTextBox.Text = FormatContent("SendData ve kalibrasyon verileri alınıyor...");
+
+            var result = await _externalDataImportService.ImportAsync();
+            ResponseTextBox.Text = FormatContent(JsonSerializer.Serialize(result, JsonWriteOptions));
+
+            var summaryLines = new List<string>
+            {
+                result.IsSuccess
+                    ? "İçe aktarma başarıyla tamamlandı."
+                    : "İçe aktarma tamamlandı ancak bazı hatalar oluştu.",
+                $"SendData kayıtları: {result.SendDataSavedCount}/{result.SendDataFetchedCount}",
+                $"Kalibrasyon kayıtları: {result.CalibrationSavedCount}/{result.CalibrationFetchedCount}"
+            };
+
+            if (!result.IsSuccess && result.Errors.Count > 0)
+            {
+                summaryLines.Add("Hatalar:");
+                summaryLines.AddRange(result.Errors);
+            }
+
+            var icon = result.IsSuccess ? MessageBoxIcon.Information : MessageBoxIcon.Error;
+            var caption = result.IsSuccess ? ExternalSaisApiConstants.DefaultInfoTitle : ApiEndpointConstants.ErrorTitle;
+            MessageBox.Show(
+                string.Join(Environment.NewLine, summaryLines),
+                caption,
+                MessageBoxButtons.OK,
+                icon);
+        }
+        catch (Exception ex)
+        {
+            ResponseTextBox.Text = FormatContent(ex.Message);
+            MessageBox.Show(
+                $"İçe aktarma başarısız oldu. {ex.Message}",
+                ApiEndpointConstants.ErrorTitle,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+        }
     }
 
     private static string CombineUrl(string baseUrl, string relative)

--- a/WinUI/Program.cs
+++ b/WinUI/Program.cs
@@ -296,6 +296,24 @@ namespace WinUI
                     }).AddStandardResilienceHandler(options =>
                         options.Retry.MaxRetryAttempts = 3);
 
+                    services.AddHttpClient<IExternalSaisApiClient, ExternalSaisApiClient>(client =>
+                    {
+                        string baseUrl = context.Configuration["ExternalSaisApi:BaseUrl"] ?? "https://10.33.3.251:446";
+                        baseUrl = baseUrl.TrimEnd('/') + "/";
+                        client.BaseAddress = new Uri(baseUrl);
+                    })
+                    .ConfigurePrimaryHttpMessageHandler(() =>
+                    {
+                        var handler = new HttpClientHandler
+                        {
+                            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
+                        };
+                        return handler;
+                    })
+                    .AddStandardResilienceHandler(options => options.Retry.MaxRetryAttempts = 3);
+
+                    services.AddScoped<IExternalDataImportService, ExternalDataImportService>();
+
                     services.AddHttpClient<IDigitalSensorDataService, DigitalSensorDataService>(client =>
                     {
                         string baseUrl = context.Configuration["Api:BaseUrl"] ?? "https://localhost:62730";

--- a/WinUI/Services/ExternalDataImportService.cs
+++ b/WinUI/Services/ExternalDataImportService.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Features.CalibrationMeasurements.Commands.Create;
+using Domain.Entities;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IExternalDataImportService
+{
+    Task<ExternalDataImportResult> ImportAsync(CancellationToken cancellationToken = default);
+}
+
+public class ExternalDataImportService(
+    IExternalSaisApiClient apiClient,
+    ISendDataService sendDataService,
+    ICalibrationMeasurementService calibrationMeasurementService,
+    IStationService stationService) : IExternalDataImportService
+{
+    private readonly IExternalSaisApiClient _apiClient = apiClient;
+    private readonly ISendDataService _sendDataService = sendDataService;
+    private readonly ICalibrationMeasurementService _calibrationMeasurementService = calibrationMeasurementService;
+    private readonly IStationService _stationService = stationService;
+
+    public async Task<ExternalDataImportResult> ImportAsync(CancellationToken cancellationToken = default)
+    {
+        var result = new ExternalDataImportResult();
+        StationDto? station = null;
+
+        try
+        {
+            station = await _stationService.GetFirstAsync();
+        }
+        catch (Exception ex)
+        {
+            result.Errors.Add($"İstasyon bilgisi alınamadı: {ex.Message}");
+        }
+
+        await ImportSendDataAsync(result, station, cancellationToken);
+        await ImportCalibrationsAsync(result, cancellationToken);
+
+        return result;
+    }
+
+    private async Task ImportSendDataAsync(ExternalDataImportResult result, StationDto? station, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ExternalSendDataDto> remoteItems;
+
+        try
+        {
+            remoteItems = await _apiClient.GetSendDataAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            result.Errors.Add($"SendData verileri alınamadı: {ex.Message}");
+            return;
+        }
+
+        result.SendDataFetchedCount = remoteItems.Count;
+
+        foreach (var item in remoteItems)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var stationId = item.StationId != Guid.Empty
+                    ? item.StationId
+                    : station?.StationId ?? Guid.Empty;
+
+                if (stationId == Guid.Empty)
+                {
+                    result.Errors.Add($"{item.ReadTime:O} tarihli SendData kaydı için istasyon bilgisi bulunamadı.");
+                    continue;
+                }
+
+                var existing = await _sendDataService.GetByReadTimeAsync(stationId, item.ReadTime);
+                if (existing != null)
+                {
+                    continue;
+                }
+
+                var entity = MapToSendData(item, station, stationId);
+                await _sendDataService.CreateAsync(entity);
+                result.SendDataSavedCount++;
+            }
+            catch (Exception ex)
+            {
+                result.Errors.Add($"SendData kaydı kaydedilemedi ({item.ReadTime:O}): {ex.Message}");
+            }
+        }
+    }
+
+    private async Task ImportCalibrationsAsync(ExternalDataImportResult result, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ExternalCalibrationRecordDto> remoteItems;
+
+        try
+        {
+            remoteItems = await _apiClient.GetCalibrationsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            result.Errors.Add($"Kalibrasyon verileri alınamadı: {ex.Message}");
+            return;
+        }
+
+        result.CalibrationFetchedCount = remoteItems.Count;
+
+        foreach (var item in remoteItems)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var command = MapToCalibrationCommand(item);
+                await _calibrationMeasurementService.CreateAsync(command);
+                result.CalibrationSavedCount++;
+            }
+            catch (Exception ex)
+            {
+                result.Errors.Add($"Kalibrasyon kaydı kaydedilemedi ({item.CalibrationDate:O}): {ex.Message}");
+            }
+        }
+    }
+
+    private static SendData MapToSendData(ExternalSendDataDto dto, StationDto? station, Guid stationId)
+    {
+        return new SendData
+        {
+            Stationid = stationId,
+            Readtime = dto.ReadTime,
+            SoftwareVersion = string.IsNullOrWhiteSpace(dto.SoftwareVersion)
+                ? station?.Software ?? string.Empty
+                : dto.SoftwareVersion,
+            AkisHizi = dto.AkisHizi ?? 0,
+            AKM = dto.AKM ?? 0,
+            CozunmusOksijen = dto.CozunmusOksijen ?? 0,
+            Debi = dto.Debi ?? 0,
+            DesarjDebi = dto.DesarjDebi,
+            HariciDebi = dto.HariciDebi,
+            HariciDebi2 = dto.HariciDebi2,
+            KOi = dto.KOi ?? 0,
+            pH = dto.pH ?? 0,
+            Sicaklik = dto.Sicaklik ?? 0,
+            Iletkenlik = dto.Iletkenlik ?? 0,
+            Period = dto.Period ?? 0,
+            AkisHizi_Status = dto.AkisHiziStatus ?? 0,
+            AKM_Status = dto.AKMStatus ?? 0,
+            CozunmusOksijen_Status = dto.CozunmusOksijenStatus ?? 0,
+            Debi_Status = dto.DebiStatus ?? 0,
+            DesarjDebi_Status = dto.DesarjDebiStatus,
+            HariciDebi_Status = dto.HariciDebiStatus,
+            HariciDebi2_Status = dto.HariciDebi2Status,
+            KOi_Status = dto.KOiStatus ?? 0,
+            pH_Status = dto.pHStatus ?? 0,
+            Sicaklik_Status = dto.SicaklikStatus ?? 0,
+            Iletkenlik_Status = dto.IletkenlikStatus ?? string.Empty,
+            IsSent = dto.IsSent ?? true,
+            SaatlikYikamaGecersiz = dto.SaatlikYikamaGecersiz ?? false,
+            HaftalikYikamaGecersiz = dto.HaftalikYikamaGecersiz ?? false,
+            KalibrasyonGecersiz = dto.KalibrasyonGecersiz ?? false,
+            AkisHiziGecersiz = dto.AkisHiziGecersiz ?? false,
+            GecersizDebi = dto.GecersizDebi ?? false,
+            TekrarVeriGecersiz = dto.TekrarVeriGecersiz ?? false,
+            GecersizOlcumBirimi = dto.GecersizOlcumBirimi ?? false
+        };
+    }
+
+    private static CreateCalibrationMeasurementCommand MapToCalibrationCommand(ExternalCalibrationRecordDto dto)
+    {
+        bool isValid = (dto.Result ?? true) && (dto.ResultZero ?? true) && (dto.ResultSpan ?? true);
+
+        return new CreateCalibrationMeasurementCommand(
+            dto.CalibrationDate,
+            string.IsNullOrWhiteSpace(dto.DBColumnName) ? "Bilinmiyor" : dto.DBColumnName,
+            dto.ZeroRef ?? 0,
+            dto.ZeroMeas ?? 0,
+            dto.ZeroDiff ?? 0,
+            dto.ZeroStd ?? 0,
+            dto.SpanRef ?? 0,
+            dto.SpanMeas ?? 0,
+            dto.SpanDiff ?? 0,
+            dto.SpanStd ?? 0,
+            dto.ResultFactor ?? 0,
+            isValid);
+    }
+}
+
+public class ExternalDataImportResult
+{
+    public int SendDataFetchedCount { get; set; }
+    public int SendDataSavedCount { get; set; }
+    public int CalibrationFetchedCount { get; set; }
+    public int CalibrationSavedCount { get; set; }
+
+    public List<string> Errors { get; } = new();
+
+    public bool IsSuccess => !Errors.Any();
+}

--- a/WinUI/Services/ExternalSaisApiClient.cs
+++ b/WinUI/Services/ExternalSaisApiClient.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WinUI.Constants;
+using WinUI.Models;
+
+namespace WinUI.Services;
+
+public interface IExternalSaisApiClient
+{
+    Task<IReadOnlyList<ExternalSendDataDto>> GetSendDataAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ExternalCalibrationRecordDto>> GetCalibrationsAsync(CancellationToken cancellationToken = default);
+}
+
+public class ExternalSaisApiClient(HttpClient httpClient) : IExternalSaisApiClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<IReadOnlyList<ExternalSendDataDto>> GetSendDataAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.GetAsync(ExternalSaisApiConstants.SendDataEndpoint, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<List<ExternalSendDataDto>>(SerializerOptions, cancellationToken);
+        return payload ?? new List<ExternalSendDataDto>();
+    }
+
+    public async Task<IReadOnlyList<ExternalCalibrationRecordDto>> GetCalibrationsAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.GetAsync(ExternalSaisApiConstants.SendCalibrationEndpoint, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<List<ExternalCalibrationRecordDto>>(SerializerOptions, cancellationToken);
+        return payload ?? new List<ExternalCalibrationRecordDto>();
+    }
+}

--- a/WinUI/appsettings.json
+++ b/WinUI/appsettings.json
@@ -1,5 +1,8 @@
 {
   "Api": {
     "BaseUrl": "https://localhost:62730"
+  },
+  "ExternalSaisApi": {
+    "BaseUrl": "https://10.33.3.251:446"
   }
 }


### PR DESCRIPTION
## Summary
- add a SendData&Calibrations button to the API settings page that imports data and reports the result to the user
- create an external SAIS API client and import service to map and persist SendData and calibration records
- register the new services and configuration for the external API endpoint

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d64fe9f0408324b325ea48dba097a2